### PR TITLE
v4.2: respect prefers-reduced-motion in UI

### DIFF
--- a/aaz-index.html
+++ b/aaz-index.html
@@ -928,6 +928,16 @@
   body.density-research .card { padding: 12px; }
   body.density-research .context-text { font-size: 12px; line-height: 1.55; }
 
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+    .mobile-card-sheet { transition: none !important; }
+  }
+
   @media (max-width: 900px) {
     .density-select { font-size: 11px; padding: 4px 7px; }
   }
@@ -73828,6 +73838,15 @@ function initTheme() {
   applyTheme('light');
 }
 
+function prefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  try {
+    return !!window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (e) {
+    return false;
+  }
+}
+
 function toggleTheme() {
   applyTheme(bodyHasDarkTheme() ? 'light' : 'dark');
 }
@@ -79969,7 +79988,10 @@ function renderScholarPanel(container) {
       syncNavigationState();
       const target = container.querySelector(`#${anchorId}`);
       if (target && typeof target.scrollIntoView === 'function') {
-        target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        const opts = prefersReducedMotion()
+          ? { block: 'start' }
+          : { block: 'start', behavior: 'smooth' };
+        target.scrollIntoView(opts);
       }
     };
   });

--- a/runtime_test.py
+++ b/runtime_test.py
@@ -116,6 +116,8 @@ def check_static_guards():
         'rows._truncated = false;',
         'rows._truncated = true;',
         'const kwicTruncated = rows && rows._truncated === true;',
+        'function prefersReducedMotion() {',
+        "window.matchMedia('(prefers-reduced-motion: reduce)'",
     ]
 
     for needle in banned:
@@ -134,6 +136,7 @@ def check_static_guards():
         'integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="',
         'rel="manifest"',
         './vendor/d3.v7.min.js',
+        '@media (prefers-reduced-motion: reduce) {',
     ]
     for needle in template_required:
         if needle not in tpl:

--- a/v3_app.js
+++ b/v3_app.js
@@ -838,6 +838,15 @@ function initTheme() {
   applyTheme('light');
 }
 
+function prefersReducedMotion() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  try {
+    return !!window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (e) {
+    return false;
+  }
+}
+
 function toggleTheme() {
   applyTheme(bodyHasDarkTheme() ? 'light' : 'dark');
 }
@@ -6979,7 +6988,10 @@ function renderScholarPanel(container) {
       syncNavigationState();
       const target = container.querySelector(`#${anchorId}`);
       if (target && typeof target.scrollIntoView === 'function') {
-        target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        const opts = prefersReducedMotion()
+          ? { block: 'start' }
+          : { block: 'start', behavior: 'smooth' };
+        target.scrollIntoView(opts);
       }
     };
   });

--- a/v3_template.html
+++ b/v3_template.html
@@ -928,6 +928,16 @@
   body.density-research .card { padding: 12px; }
   body.density-research .context-text { font-size: 12px; line-height: 1.55; }
 
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+    .mobile-card-sheet { transition: none !important; }
+  }
+
   @media (max-width: 900px) {
     .density-select { font-size: 11px; padding: 4px 7px; }
   }


### PR DESCRIPTION
## Summary
- add CSS `@media (prefers-reduced-motion: reduce)` override to reduce transitions/animations
- disable smooth anchor scrolling in scholar section when reduced-motion is enabled
- add static guard fragments in `runtime_test.py` for reduced-motion CSS/JS hooks
- rebuild standalone artifact `aaz-index.html`

## Validation
- `python scripts/check_encoding.py`
- `python scripts/validate_content.py app_data.json`
- `python scripts/build_aaz_index.py`
- `python -c "import runtime_test; print(runtime_test.check_static_guards())"`

Closes #53