### PR TITLE
[codex] Add Apache 2.0 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,192 @@
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+Copyright 2026 gasyoun
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 - **Экспериментальный `home/home_decl` скрыт из основной навигации**; классический `home/home` остаётся публичным стартовым экраном.
 - **VIZ hardening**: добавлен helper [scripts/viz/viz-state.js](scripts/viz/viz-state.js) для query-state в hash, VIZ-01 получил `Play/Pause`, VIZ-03 переведён в компактную сетку, VIZ-07 защищает подписи справа от наложений.
 - **Документация очищена**: восстановлен битый раздел 1 в [CODEX_WORKFLOW_RU.md](CODEX_WORKFLOW_RU.md), убраны служебные `[cite:*]` из [CODEX_VISUALIZATIONS_RU.md](CODEX_VISUALIZATIONS_RU.md).
-- **LICENSE не выбран автоматически**: это отдельное governance-решение владельца проекта.
+- **Лицензия определена**: проект распространяется под Apache License 2.0.
 
 ### v4.3 (2026-04-20)
 
@@ -215,6 +215,10 @@ $env:Path = 'D:\Codex 2026\tools\node-v24.14.1-win-x64;' + $env:Path
 python -m pip install -r requirements.txt
 ```
 
+## Лицензия
+
+BookIndex распространяется под [Apache License 2.0](LICENSE). Это относится к коду, документации, данным и собираемому standalone-артефакту [aaz-index.html](aaz-index.html), если в отдельных файлах явно не указано иное.
+
 Ожидается:
 
 - [scripts/validate_content.py](scripts/validate_content.py): `0 errors` (допустимы известные warning по дублям данных).
@@ -240,6 +244,7 @@ python scripts/content_report.py --format json
 | [app_data.json](app_data.json) | База контента (только чтение) |
 | [data/modules/](data/modules/) | Логически разделённые модули данных (`manifest.json` + тематические JSON) |
 | [runtime_test.py](runtime_test.py) | Runtime smoke и статические guard'ы |
+| [LICENSE](LICENSE) | Apache License 2.0 для проекта |
 | [scripts/build_aaz_index.mjs](scripts/build_aaz_index.mjs) / [scripts/build_aaz_index.py](scripts/build_aaz_index.py) | Основная Node-сборка и legacy Python-сборка `aaz-index.html` |
 | [scripts/split_app_data.py](scripts/split_app_data.py) | Разбиение `app_data.json` на модульные JSON |
 | [scripts/assemble_app_data.py](scripts/assemble_app_data.py) | Склейка модульных JSON обратно в `app_data.json` |

--- a/improvements_plan.md
+++ b/improvements_plan.md
@@ -4,7 +4,7 @@
 
 ## 0. Текущее подтверждение, 2026-05-01
 
-- GitHub: открытых PR нет; открытая issue одна — [#82](https://github.com/gasyoun/BookIndex/issues/82) по LICENSE.
+- GitHub: открытых PR нет; issue [#82](https://github.com/gasyoun/BookIndex/issues/82) по LICENSE получила owner decision — Apache License 2.0.
 - PR [#81](https://github.com/gasyoun/BookIndex/pull/81) остаётся последним крупным merge-scope: VIZ-00..VIZ-07 уже реализованы, в v4.4 по ним актуальны только стабилизация, smoke и polish.
 - Локальная текущая волна UI hardening расширена: кроме gallery / Russian evolution / phonetic laws / tasks / lectures / page trends, вынесены в CSS повторяющиеся scholar intro, bibliography, controversy, original forms, birch filters/tables, chronology, isoglosses, slovo, accent paradigms, correspondence table и reconstruction styles.
 - После текущей волны source-level ` style="..."` в `v3_app.js` снижен с 172 до 11 и закреплён allowlist guard-командой `npm run check:ui`; production `home/home` и скрытый experimental `home/home_decl` переведены на общие CSS-классы/media-query, фиксированные category dots / moderator mark / timeline empty state / SVG cursor/root styles вынесены в CSS. Оставшиеся случаи — осознанные динамические custom properties, data-driven widths/colors и SVG text styling.
@@ -15,7 +15,7 @@
 - `origin/main` содержит v4.4-слой стабилизации; локальный `main` синхронизирован с `origin/main`.
 - PR [#81](https://github.com/gasyoun/BookIndex/pull/81) смержен 2026-04-20: VIZ-00..VIZ-07 уже реализованы, это больше не будущий feature-scope.
 - Issues [#73](https://github.com/gasyoun/BookIndex/issues/73)..[#80](https://github.com/gasyoun/BookIndex/issues/80) по VIZ закрыты как completed.
-- Единственная открытая GitHub-задача сейчас: [#82](https://github.com/gasyoun/BookIndex/issues/82) — owner decision по LICENSE.
+- Единственная GitHub-задача вне стабилизационного PR: [#82](https://github.com/gasyoun/BookIndex/issues/82) — внедрить Apache License 2.0 и закрыть issue через PR.
 - Локально в текущей волне подготовлены UI-правки в `v3_app.js` и `v3_template.html`: широкий вынос повторяющихся inline styles в CSS для home, карточек/списков, learning-панелей, scholar/VIZ-поверхностей и SVG-root/cursor классов.
 
 ## 2. Что уже закрыто и не должно оставаться как open work
@@ -35,14 +35,14 @@
 - До merge/PR остаётся только финальная human review диффа и упаковка изменений; новых feature-scope задач в этот цикл не добавлять.
 - После любых дополнительных runtime/template правок по-прежнему пересобирать `aaz-index.html` и запускать полный gate.
 - Не переписывать крупные static/container templates без отдельного будущего scope: оставшиеся `innerHTML` места в основном являются panel-shell/table templates, а не быстрыми data-bearing row builders.
-- LICENSE не выбирать в коде или README до явного решения владельца по issue #82.
+- LICENSE теперь выбран владельцем: Apache License 2.0. Открытая техническая часть — добавить файл лицензии, обновить README и закрыть #82 через PR.
 
 ## 4. Что было обновлено в плане
 
 - Формулировка "синхронизировать `package-lock.json` с `package.json`" убрана как открытая задача. Новая формулировка: "периодически проверять `npm ci` на supported Node".
 - Локальные инструкции уточнены: системный `npm` может отсутствовать в PATH; bundled Node 20.17 дает engine warning для Vite 8, поэтому для локальных smoke лучше использовать Node 24 или Node >=20.19.
 - VIZ-00..VIZ-07 перенесены из раздела "реализовать" в раздел "стабилизировать, smoke-test, polish".
-- "Создать отдельную задачу по LICENSE" заменено на "держать открытой #82 до owner decision".
+- "Держать открытой #82 до owner decision" заменено на "внедрить Apache License 2.0 и закрыть #82 через PR".
 - Обязательный шаг текущей UI-волны зафиксирован: после выноса CSS из `v3_app.js`/`v3_template.html` пересобрать `aaz-index.html`, затем прогнать проверки.
 
 ## 5. Обновленный порядок работ


### PR DESCRIPTION
## Summary
- Adds Apache License 2.0 as the repository license.
- Updates README license wording for code, docs, data, and the standalone artifact.
- Updates the v4.4 stabilization plan now that #82 has an Apache-2.0 owner decision.

## Validation
- `python scripts/check_encoding.py`
- `git diff --check`

Closes #82