### PR TITLE
[codex] Добавить корпусную оболочку UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - **VIZ hardening**: добавлен helper [scripts/viz/viz-state.js](scripts/viz/viz-state.js) для query-state в hash, VIZ-01 получил `Play/Pause`, VIZ-03 переведён в компактную сетку, VIZ-07 защищает подписи справа от наложений.
 - **Документация очищена**: восстановлен битый раздел 1 в [CODEX_WORKFLOW_RU.md](CODEX_WORKFLOW_RU.md), убраны служебные `[cite:*]` из [CODEX_VISUALIZATIONS_RU.md](CODEX_VISUALIZATIONS_RU.md).
 - **Лицензия определена**: проект распространяется под Apache License 2.0.
+- **Заложена корпусная оболочка UI**: runtime создаёт `APP_DATA.corpus` с текущей книгой как первым источником, принимает aliases вида `#v4/books/<book_id>/...` и резервирует тип `video_catalog` для будущих 200 видео с тайм-кодами и стенограммами.
 
 ### v4.3 (2026-04-20)
 
@@ -218,6 +219,12 @@ python -m pip install -r requirements.txt
 ## Лицензия
 
 BookIndex распространяется под [Apache License 2.0](LICENSE). Это относится к коду, документации, данным и собираемому standalone-артефакту [aaz-index.html](aaz-index.html), если в отдельных файлах явно не указано иное.
+
+## Корпусная оболочка
+
+Текущий интерфейс остаётся совместимым с `#v4/...`, но runtime уже нормализует лёгкий metadata-слой `APP_DATA.corpus`. Первый источник — текущая книга `zaliznyak-aaz-index`; будущие маршруты могут использовать aliases вида `#v4/books/<book_id>/names/list`, которые канонизируются обратно в существующий route state.
+
+В `APP_DATA.corpus.source_types` зарезервирован тип `video_catalog`: он предназначен для каталога примерно 200 видео Зализняка с тайм-кодами и стенограммами. Это пока metadata-задел, без миграции `schema_version` и без изменения структуры основных сущностей.
 
 Ожидается:
 

--- a/aaz-index.html
+++ b/aaz-index.html
@@ -176,6 +176,31 @@
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
   }
   .header-search-results.open { display: block; }
+  .corpus-status {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 4px;
+  }
+  .corpus-chip {
+    background: var(--surface-soft);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    color: var(--muted);
+    display: inline-flex;
+    font-size: 10px;
+    line-height: 1.25;
+    max-width: 100%;
+    padding: 2px 6px;
+  }
+  .corpus-chip.active {
+    color: var(--title);
+    font-weight: 600;
+  }
+  .corpus-chip.planned {
+    border-style: dashed;
+  }
   .header-search-item {
     padding: 7px 10px;
     border-bottom: 1px solid #f0e8d8;
@@ -4081,6 +4106,7 @@
       <div class="header-search-results" id="global-search-results"></div>
     </div>
   </h1>
+  <div class="corpus-status" id="corpus-status" aria-label="Корпус и текущий источник"></div>
   <div class="entity-switcher" id="entity-switcher"></div>
   <div class="tabs" id="tabs"></div>
   <nav class="breadcrumb" id="breadcrumb-nav" aria-label="Навигация"></nav>
@@ -76025,7 +76051,7 @@ const APP_DATA_SCHEMA_CURRENT = 2;
 const KWIC_MAX_SNIPPETS_PER_PAGE = 24;
 const KWIC_MAX_SNIPPET_LENGTH = 420;
 const KWIC_MAX_ROWS = 1200;
-const APP_BUILD_ID = '17f208e16a34';
+const APP_BUILD_ID = 'b1e286b2222a';
 const DESCRIPTION_FIELDS_WITH_NORMALIZED_YO = new Set([
   'desc',
   'about',
@@ -76101,11 +76127,69 @@ function migrateAppDataSchema(data) {
   }
 }
 
+function buildDefaultCorpusRegistry() {
+  const stats = APP_DATA && APP_DATA.book_stats && typeof APP_DATA.book_stats === 'object'
+    ? APP_DATA.book_stats
+    : {};
+  const pages = Number.isFinite(Number(stats.pages_total)) ? Number(stats.pages_total) : 404;
+  return {
+    schema_version: 1,
+    active_book_id: 'zaliznyak-aaz-index',
+    books: [
+      {
+        book_id: 'zaliznyak-aaz-index',
+        title: 'Из жизни слов и языков',
+        author: 'А. А. Зализняк',
+        year: 2026,
+        edition: 'Альпина нон-фикшн',
+        status: 'active',
+        source_type: 'book',
+        pages_total: pages,
+        default_route: '#v4/home/home',
+        content_modules: ['app_data.json'],
+      },
+    ],
+    source_types: [
+      {
+        type: 'book',
+        title: 'Книги',
+        status: 'active',
+      },
+      {
+        type: 'video_catalog',
+        title: 'Видеокаталог',
+        status: 'planned',
+        planned_count: 200,
+        supports: ['timecodes', 'transcripts'],
+      },
+    ],
+  };
+}
+
+function normalizeCorpusRegistry() {
+  if (!APP_DATA || typeof APP_DATA !== 'object') return;
+  const defaults = buildDefaultCorpusRegistry();
+  const raw = APP_DATA.corpus && typeof APP_DATA.corpus === 'object' ? APP_DATA.corpus : {};
+  const books = Array.isArray(raw.books) && raw.books.length ? raw.books : defaults.books;
+  const sourceTypes = Array.isArray(raw.source_types) && raw.source_types.length ? raw.source_types : defaults.source_types;
+  APP_DATA.corpus = {
+    ...defaults,
+    ...raw,
+    books,
+    source_types: sourceTypes,
+  };
+  const activeId = typeof APP_DATA.corpus.active_book_id === 'string' ? APP_DATA.corpus.active_book_id : '';
+  if (!books.some(book => book && book.book_id === activeId)) {
+    APP_DATA.corpus.active_book_id = defaults.active_book_id;
+  }
+}
+
 function normalizeAppData() {
   if (!APP_DATA) return;
 
   APP_DATA.labels = APP_DATA.labels || {};
   APP_DATA.colors = APP_DATA.colors || {};
+  normalizeCorpusRegistry();
 
   // Legacy compatibility: older datasets may still use schoolchild/lecture_host.
   APP_DATA.labels.literator = 'Носитель языка';
@@ -76654,6 +76738,30 @@ let familiesGraphRenderToken = 0;
 let familiesGraphLayoutPromiseCache = new Map();
 let workersLifecycleWired = false;
 let contextEntityLinkEntriesCache = null;
+
+function getCorpusRegistry() {
+  if (!APP_DATA || !APP_DATA.corpus || typeof APP_DATA.corpus !== 'object') {
+    return buildDefaultCorpusRegistry();
+  }
+  return APP_DATA.corpus;
+}
+
+function getCorpusBooks() {
+  const books = getCorpusRegistry().books;
+  return Array.isArray(books) ? books.filter(book => book && typeof book.book_id === 'string') : [];
+}
+
+function getActiveBook() {
+  const registry = getCorpusRegistry();
+  const books = getCorpusBooks();
+  return books.find(book => book.book_id === registry.active_book_id) || books[0] || buildDefaultCorpusRegistry().books[0];
+}
+
+function getPlannedVideoCatalogSource() {
+  const sourceTypes = getCorpusRegistry().source_types;
+  if (!Array.isArray(sourceTypes)) return null;
+  return sourceTypes.find(source => source && source.type === 'video_catalog') || null;
+}
 let subjectCrosslinksLookupCache = null;
 let reverseEdgesCache = null;
 let SUBJECT_BY_LEXICON_INDEX = null;
@@ -77894,7 +78002,13 @@ function parseHashRoute(hash) {
     decodedParts.push(decoded);
   }
 
-  const parts = decodedParts[0] === HASH_ROUTE_PREFIX ? decodedParts.slice(1) : decodedParts;
+  let parts = decodedParts[0] === HASH_ROUTE_PREFIX ? decodedParts.slice(1) : decodedParts;
+  if (parts[0] === 'books' && parts[1]) {
+    const bookId = parts[1];
+    const knownBook = getCorpusBooks().some(book => book.book_id === bookId);
+    if (!knownBook) return null;
+    parts = parts.slice(2);
+  }
   if (!parts.length || parts.length > MAX_HASH_PARTS) return null;
   return { parts, query: query.slice(0, 240) };
 }
@@ -77970,6 +78084,36 @@ function updateBackButton() {
   btn.style.display = historyStack.length > 1 ? 'inline-flex' : 'none';
 }
 
+function renderCorpusStatus() {
+  const host = document.getElementById('corpus-status');
+  if (!host) return;
+  host.innerHTML = '';
+  const activeBook = getActiveBook();
+  const books = getCorpusBooks();
+  const videoCatalog = getPlannedVideoCatalogSource();
+
+  const bookChip = document.createElement('span');
+  bookChip.className = 'corpus-chip active';
+  bookChip.textContent = `${activeBook.title || 'Текущая книга'} · ${activeBook.author || 'А. А. Зализняк'}`;
+  safeSetAttr(bookChip, 'title', `Текущий источник: ${activeBook.title || activeBook.book_id}`);
+  host.appendChild(bookChip);
+
+  const scopeChip = document.createElement('span');
+  scopeChip.className = 'corpus-chip';
+  scopeChip.textContent = books.length > 1 ? `Корпус: ${books.length} книг` : 'Корпус: 1 книга';
+  safeSetAttr(scopeChip, 'title', 'Будущая точка переключения между книгой и всем корпусом');
+  host.appendChild(scopeChip);
+
+  if (videoCatalog) {
+    const videoChip = document.createElement('span');
+    videoChip.className = 'corpus-chip planned';
+    const count = Number.isFinite(Number(videoCatalog.planned_count)) ? Number(videoCatalog.planned_count) : 200;
+    videoChip.textContent = `Видео: ${count} с тайм-кодами и стенограммами`;
+    safeSetAttr(videoChip, 'title', 'Запланированный тип источника: видеокаталог с тайм-кодами и стенограммами');
+    host.appendChild(videoChip);
+  }
+}
+
 async function copyCurrentUrl() {
   const canonicalHash = buildHashFromState();
   const canonicalUrl = (() => {
@@ -78004,6 +78148,7 @@ async function copyCurrentUrl() {
 function syncNavigationState() {
   if (!isNavigatingHistory) pushHistoryState();
   updateBackButton();
+  renderCorpusStatus();
   renderBreadcrumbs(buildHashFromState());
   persistViewState();
   if (suppressHashSync) return;
@@ -79344,7 +79489,7 @@ function registerAppServiceWorker() {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') return;
   if (!('serviceWorker' in navigator)) return;
   const buildIdRaw = String(APP_BUILD_ID || '').trim();
-  const buildId = buildIdRaw && buildIdRaw !== '17f208e16a34' ? buildIdRaw : 'dev';
+  const buildId = buildIdRaw && buildIdRaw !== 'b1e286b2222a' ? buildIdRaw : 'dev';
   const swUrl = `./sw.js?v=${encodeURIComponent(buildId)}`;
   const register = () => {
     const hadController = !!navigator.serviceWorker.controller;

--- a/tests/e2e/smoke.spec.new.js
+++ b/tests/e2e/smoke.spec.new.js
@@ -12,6 +12,22 @@ test.describe('aaz-index smoke', () => {
     await expect(page.locator('#home-stats-grid .home-stat-cell')).toHaveCount(8);
   });
 
+  test('corpus shell registers current book and accepts book route aliases', async ({ page }) => {
+    await page.goto('/aaz-index.html#v4/books/zaliznyak-aaz-index/home/home');
+    await expect(page.locator('.home-panel')).toBeVisible();
+    await expect(page.locator('#corpus-status .corpus-chip.active')).toContainText('Из жизни слов и языков');
+    await expect(page.locator('#corpus-status')).toContainText('Видео: 200');
+
+    const corpus = await page.evaluate(() => window.APP_DATA && window.APP_DATA.corpus);
+    expect(corpus.active_book_id).toBe('zaliznyak-aaz-index');
+    expect(corpus.books[0].source_type).toBe('book');
+    expect(corpus.source_types.some((source) => source.type === 'video_catalog' && source.planned_count === 200)).toBe(true);
+
+    await page.goto('/aaz-index.html#v4/books/zaliznyak-aaz-index/names/list');
+    await expect(page.locator('#name-list .name-item').first()).toBeVisible();
+    await expect(page).toHaveURL(/#v4\/names\/list$/);
+  });
+
   test('PWA manifest and service worker are available', async ({ page }) => {
     await page.goto('/aaz-index.html#home/home');
     const manifestLink = page.locator('link[rel="manifest"]');

--- a/types/app-data.d.ts
+++ b/types/app-data.d.ts
@@ -41,9 +41,41 @@ export interface GraphEdge {
   [key: string]: unknown;
 }
 
+export interface CorpusBook {
+  book_id: string;
+  title?: string;
+  author?: string;
+  year?: number;
+  edition?: string;
+  status?: string;
+  source_type?: string;
+  pages_total?: number;
+  default_route?: string;
+  content_modules?: string[];
+  [key: string]: unknown;
+}
+
+export interface CorpusSourceType {
+  type: string;
+  title?: string;
+  status?: string;
+  planned_count?: number;
+  supports?: string[];
+  [key: string]: unknown;
+}
+
+export interface CorpusRegistry {
+  schema_version?: number;
+  active_book_id?: string;
+  books?: CorpusBook[];
+  source_types?: CorpusSourceType[];
+  [key: string]: unknown;
+}
+
 export interface AppData {
   schema_version?: number;
   schema_migrations?: string[];
+  corpus?: CorpusRegistry;
   labels?: Record<string, string>;
   colors?: Record<string, string>;
   epoch_labels?: Record<string, string>;

--- a/v3_app.js
+++ b/v3_app.js
@@ -85,11 +85,69 @@ function migrateAppDataSchema(data) {
   }
 }
 
+function buildDefaultCorpusRegistry() {
+  const stats = APP_DATA && APP_DATA.book_stats && typeof APP_DATA.book_stats === 'object'
+    ? APP_DATA.book_stats
+    : {};
+  const pages = Number.isFinite(Number(stats.pages_total)) ? Number(stats.pages_total) : 404;
+  return {
+    schema_version: 1,
+    active_book_id: 'zaliznyak-aaz-index',
+    books: [
+      {
+        book_id: 'zaliznyak-aaz-index',
+        title: 'Из жизни слов и языков',
+        author: 'А. А. Зализняк',
+        year: 2026,
+        edition: 'Альпина нон-фикшн',
+        status: 'active',
+        source_type: 'book',
+        pages_total: pages,
+        default_route: '#v4/home/home',
+        content_modules: ['app_data.json'],
+      },
+    ],
+    source_types: [
+      {
+        type: 'book',
+        title: 'Книги',
+        status: 'active',
+      },
+      {
+        type: 'video_catalog',
+        title: 'Видеокаталог',
+        status: 'planned',
+        planned_count: 200,
+        supports: ['timecodes', 'transcripts'],
+      },
+    ],
+  };
+}
+
+function normalizeCorpusRegistry() {
+  if (!APP_DATA || typeof APP_DATA !== 'object') return;
+  const defaults = buildDefaultCorpusRegistry();
+  const raw = APP_DATA.corpus && typeof APP_DATA.corpus === 'object' ? APP_DATA.corpus : {};
+  const books = Array.isArray(raw.books) && raw.books.length ? raw.books : defaults.books;
+  const sourceTypes = Array.isArray(raw.source_types) && raw.source_types.length ? raw.source_types : defaults.source_types;
+  APP_DATA.corpus = {
+    ...defaults,
+    ...raw,
+    books,
+    source_types: sourceTypes,
+  };
+  const activeId = typeof APP_DATA.corpus.active_book_id === 'string' ? APP_DATA.corpus.active_book_id : '';
+  if (!books.some(book => book && book.book_id === activeId)) {
+    APP_DATA.corpus.active_book_id = defaults.active_book_id;
+  }
+}
+
 function normalizeAppData() {
   if (!APP_DATA) return;
 
   APP_DATA.labels = APP_DATA.labels || {};
   APP_DATA.colors = APP_DATA.colors || {};
+  normalizeCorpusRegistry();
 
   // Legacy compatibility: older datasets may still use schoolchild/lecture_host.
   APP_DATA.labels.literator = 'Носитель языка';
@@ -638,6 +696,30 @@ let familiesGraphRenderToken = 0;
 let familiesGraphLayoutPromiseCache = new Map();
 let workersLifecycleWired = false;
 let contextEntityLinkEntriesCache = null;
+
+function getCorpusRegistry() {
+  if (!APP_DATA || !APP_DATA.corpus || typeof APP_DATA.corpus !== 'object') {
+    return buildDefaultCorpusRegistry();
+  }
+  return APP_DATA.corpus;
+}
+
+function getCorpusBooks() {
+  const books = getCorpusRegistry().books;
+  return Array.isArray(books) ? books.filter(book => book && typeof book.book_id === 'string') : [];
+}
+
+function getActiveBook() {
+  const registry = getCorpusRegistry();
+  const books = getCorpusBooks();
+  return books.find(book => book.book_id === registry.active_book_id) || books[0] || buildDefaultCorpusRegistry().books[0];
+}
+
+function getPlannedVideoCatalogSource() {
+  const sourceTypes = getCorpusRegistry().source_types;
+  if (!Array.isArray(sourceTypes)) return null;
+  return sourceTypes.find(source => source && source.type === 'video_catalog') || null;
+}
 let subjectCrosslinksLookupCache = null;
 let reverseEdgesCache = null;
 let SUBJECT_BY_LEXICON_INDEX = null;
@@ -1878,7 +1960,13 @@ function parseHashRoute(hash) {
     decodedParts.push(decoded);
   }
 
-  const parts = decodedParts[0] === HASH_ROUTE_PREFIX ? decodedParts.slice(1) : decodedParts;
+  let parts = decodedParts[0] === HASH_ROUTE_PREFIX ? decodedParts.slice(1) : decodedParts;
+  if (parts[0] === 'books' && parts[1]) {
+    const bookId = parts[1];
+    const knownBook = getCorpusBooks().some(book => book.book_id === bookId);
+    if (!knownBook) return null;
+    parts = parts.slice(2);
+  }
   if (!parts.length || parts.length > MAX_HASH_PARTS) return null;
   return { parts, query: query.slice(0, 240) };
 }
@@ -1954,6 +2042,36 @@ function updateBackButton() {
   btn.style.display = historyStack.length > 1 ? 'inline-flex' : 'none';
 }
 
+function renderCorpusStatus() {
+  const host = document.getElementById('corpus-status');
+  if (!host) return;
+  host.innerHTML = '';
+  const activeBook = getActiveBook();
+  const books = getCorpusBooks();
+  const videoCatalog = getPlannedVideoCatalogSource();
+
+  const bookChip = document.createElement('span');
+  bookChip.className = 'corpus-chip active';
+  bookChip.textContent = `${activeBook.title || 'Текущая книга'} · ${activeBook.author || 'А. А. Зализняк'}`;
+  safeSetAttr(bookChip, 'title', `Текущий источник: ${activeBook.title || activeBook.book_id}`);
+  host.appendChild(bookChip);
+
+  const scopeChip = document.createElement('span');
+  scopeChip.className = 'corpus-chip';
+  scopeChip.textContent = books.length > 1 ? `Корпус: ${books.length} книг` : 'Корпус: 1 книга';
+  safeSetAttr(scopeChip, 'title', 'Будущая точка переключения между книгой и всем корпусом');
+  host.appendChild(scopeChip);
+
+  if (videoCatalog) {
+    const videoChip = document.createElement('span');
+    videoChip.className = 'corpus-chip planned';
+    const count = Number.isFinite(Number(videoCatalog.planned_count)) ? Number(videoCatalog.planned_count) : 200;
+    videoChip.textContent = `Видео: ${count} с тайм-кодами и стенограммами`;
+    safeSetAttr(videoChip, 'title', 'Запланированный тип источника: видеокаталог с тайм-кодами и стенограммами');
+    host.appendChild(videoChip);
+  }
+}
+
 async function copyCurrentUrl() {
   const canonicalHash = buildHashFromState();
   const canonicalUrl = (() => {
@@ -1988,6 +2106,7 @@ async function copyCurrentUrl() {
 function syncNavigationState() {
   if (!isNavigatingHistory) pushHistoryState();
   updateBackButton();
+  renderCorpusStatus();
   renderBreadcrumbs(buildHashFromState());
   persistViewState();
   if (suppressHashSync) return;

--- a/v3_template.html
+++ b/v3_template.html
@@ -176,6 +176,31 @@
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
   }
   .header-search-results.open { display: block; }
+  .corpus-status {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 4px;
+  }
+  .corpus-chip {
+    background: var(--surface-soft);
+    border: 1px solid var(--line);
+    border-radius: 4px;
+    color: var(--muted);
+    display: inline-flex;
+    font-size: 10px;
+    line-height: 1.25;
+    max-width: 100%;
+    padding: 2px 6px;
+  }
+  .corpus-chip.active {
+    color: var(--title);
+    font-weight: 600;
+  }
+  .corpus-chip.planned {
+    border-style: dashed;
+  }
   .header-search-item {
     padding: 7px 10px;
     border-bottom: 1px solid #f0e8d8;
@@ -4081,6 +4106,7 @@
       <div class="header-search-results" id="global-search-results"></div>
     </div>
   </h1>
+  <div class="corpus-status" id="corpus-status" aria-label="Корпус и текущий источник"></div>
   <div class="entity-switcher" id="entity-switcher"></div>
   <div class="tabs" id="tabs"></div>
   <nav class="breadcrumb" id="breadcrumb-nav" aria-label="Навигация"></nav>


### PR DESCRIPTION
## Summary
- Добавляет runtime-нормализацию `APP_DATA.corpus` без повышения `schema_version`: текущая книга регистрируется как первый источник `zaliznyak-aaz-index`.
- Добавляет поддержку alias-маршрутов `#v4/books/<book_id>/...` с канонизацией обратно в существующий route state.
- Показывает в header компактный corpus/source status и резервирует тип `video_catalog` для будущих 200 видео с тайм-кодами и стенограммами.
- Обновляет TS-типы, README, e2e smoke и пересобирает `aaz-index.html`.

## Validation
- `npm run check` через bundled Node 24 (`67/67` Playwright)
- `python scripts/check_encoding.py`
- `python scripts/validate_content.py app_data.json` (`0 errors`; прежние duplicate-head warnings)
- `NODE_BINARY=D:\Codex 2026\tools\node-v24.14.1-win-x64\node.exe python runtime_test.py` (`21/21`)
- `git diff --check` (только CRLF warnings)

Refs #85