### PR TITLE
[codex] Fix audited contrast debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Live GitHub Pages health checks plus Lighthouse and axe accessibility quality gates.
 
 ### Changed
+- Raised the axe accessibility gate to require zero critical and zero serious violations on audited routes.
+- Darkened muted helper text in the app shell so route metadata, index summary chips, chapter labels and KWIC controls meet contrast requirements.
 - Opted GitHub workflows into the Node 24 JavaScript action runtime ahead of the June 2026 migration.
 
 ## [2.2.0] - 2026-05-17

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 *   **Полная E2E-проверка**: `npm run check`
 *   **Security guard**: `npm run check:security && npm run check:security:static`
 *   **Performance budget**: `npm run check:perf`
-*   **Post-deploy gates**: `npm run check:postdeploy` проверяет live GitHub Pages, Lighthouse и axe accessibility.
+*   **Post-deploy gates**: `npm run check:postdeploy` проверяет live GitHub Pages, Lighthouse и axe accessibility (`0` critical / `0` serious).
 
 ## Audit Summary
 

--- a/scripts/check_lighthouse_a11y.mjs
+++ b/scripts/check_lighthouse_a11y.mjs
@@ -71,18 +71,18 @@ function fail(message) {
 }
 
 async function runLighthouse() {
-  const chrome = await chromeLauncher.launch({
-    chromePath: chromium.executablePath(),
-    chromeFlags: [
-      '--headless=new',
-      '--no-sandbox',
-      '--disable-dev-shm-usage',
-      '--disable-gpu',
-    ],
-  });
+  for (const target of lighthouseTargets) {
+    const chrome = await chromeLauncher.launch({
+      chromePath: chromium.executablePath(),
+      chromeFlags: [
+        '--headless=new',
+        '--no-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu',
+      ],
+    });
 
-  try {
-    for (const target of lighthouseTargets) {
+    try {
       const result = await lighthouse(target.url.href, {
         port: chrome.port,
         logLevel: 'error',
@@ -109,19 +109,19 @@ async function runLighthouse() {
           console.log(`[lighthouse] OK ${target.label} ${category} ${readable}`);
         }
       }
-    }
-  } finally {
-    try {
-      await chrome.kill();
-    } catch (error) {
-      console.warn(`[lighthouse] Chrome cleanup warning: ${error.message}`);
+    } finally {
+      try {
+        await chrome.kill();
+      } catch (error) {
+        console.warn(`[lighthouse] Chrome cleanup warning: ${error.message}`);
+      }
     }
   }
 }
 
 async function runAxe() {
   const maxCritical = thresholdFromEnv('BOOKINDEX_A11Y_MAX_CRITICAL', 0);
-  const maxSerious = thresholdFromEnv('BOOKINDEX_A11Y_MAX_SERIOUS', 1);
+  const maxSerious = thresholdFromEnv('BOOKINDEX_A11Y_MAX_SERIOUS', 0);
   const browser = await chromium.launch();
 
   try {

--- a/v3_template.html
+++ b/v3_template.html
@@ -73,7 +73,7 @@
     --bg: #faf8f3;
     --text: #1a1a1a;
     --title: #5a3818;
-    --muted: #888;
+    --muted: #665f57;
     --line-strong: #8a7050;
     --line: #d4c8b0;
     --line-soft: #f0e8d8;
@@ -85,7 +85,7 @@
     --color-gold: #b8860b;
     --color-orange: #cf7a2f;
     --color-success: #2e8b57;
-    --color-text-muted: #888;
+    --color-text-muted: #665f57;
     --primary: var(--color-primary);
   }
   * { box-sizing: border-box; }
@@ -2285,7 +2285,7 @@
     min-width: 96px;
   }
   .home-route-pages {
-    color: #888;
+    color: var(--muted);
     font-size: 11px;
     white-space: nowrap;
   }
@@ -2423,10 +2423,10 @@
     padding: 6px 12px;
   }
   .chapter-filter-count {
-    color: #888;
+    color: var(--muted);
   }
   .bar-label small {
-    color: #999;
+    color: var(--muted);
   }
   .card-missing-message {
     color: #999;


### PR DESCRIPTION
## What changed

- Darkened the app shell muted text token from `#888` to `#665f57` so helper text clears WCAG contrast on white and pale panels.
- Routed home route page metadata, chapter filter counts, and chapter bar page labels through the muted token instead of weaker literal grays.
- Rebuilt `aaz-index.html` from `v3_template.html`.
- Tightened the axe post-deploy budget to require `0` critical and `0` serious violations on audited routes.
- Updated README and changelog to document the stricter accessibility gate.
- Made Lighthouse audits use a fresh Chrome instance per target to avoid target-to-target state bleed.

## Validation

- `npm run build:vite`
- `npm run build`
- `npm run check:security`
- `npm run check:security:static`
- `npm run check:perf`
- `python runtime_test.py`
- `python scripts/check_encoding.py`
- `npm run check` (`103 passed`)
- Local static server with `BOOKINDEX_BASE_URL=http://127.0.0.1:4174/ npm run check:postdeploy`

## Result

The local post-deploy gate now reports `0 critical, 0 serious` for landing, app-home, app-list, and app-kwic. Lighthouse app accessibility improved to the mid/high 90s while performance, best-practices and SEO remain above budget.