### PR TITLE
[codex] Harden script CSP hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Raised the axe accessibility gate to require zero critical and zero serious violations on audited routes.
 - Darkened muted helper text in the app shell so route metadata, index summary chips, chapter labels and KWIC controls meet contrast requirements.
+- Replaced script CSP `unsafe-inline` with build-generated SHA-256 hashes for the landing page and standalone app shell.
 - Opted GitHub workflows into the Node 24 JavaScript action runtime ahead of the June 2026 migration.
 
 ## [2.2.0] - 2026-05-17

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 *   **Проверка типов**: `npm run typecheck`
 *   **Полная E2E-проверка**: `npm run check`
 *   **Security guard**: `npm run check:security && npm run check:security:static`
+*   **CSP hardening**: inline scripts use SHA-256 CSP hashes generated at build time; the static and post-deploy checks fail if `script-src` regresses to `unsafe-inline`.
 *   **Performance budget**: `npm run check:perf`
 *   **Post-deploy gates**: `npm run check:postdeploy` проверяет live GitHub Pages, Lighthouse и axe accessibility (`0` critical / `0` serious).
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'sha256-ZWmIY/3FP/2NF9G4n7qGWjNRrpHRKm0b5Qm4gQ6MhT8='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" />
   <meta name="description" content="Зализнякиада: вводная страница к BookIndex, сопроводительному сайту к книге А. А. Зализняка «Из жизни слов и языков»." />
   <meta name="robots" content="index, follow, max-image-preview:large" />
   <meta name="theme-color" content="#5a3818" />

--- a/runtime_test.py
+++ b/runtime_test.py
@@ -32,7 +32,7 @@ TEXT_REQUIRED = {
     "index.html": [
         "Content-Security-Policy",
         "default-src 'self'",
-        "script-src 'self' 'unsafe-inline'",
+        "script-src 'self' 'sha256-",
         'rel="manifest" href="./manifest.webmanifest"',
         'rel="canonical" href="https://gasyoun.github.io/BookIndex/index.html"',
         'property="og:image"',
@@ -42,6 +42,7 @@ TEXT_REQUIRED = {
     "aaz-index.html": [
         "Content-Security-Policy",
         "default-src 'self'",
+        "script-src 'self' 'sha256-",
         'rel="manifest" href="./manifest.webmanifest"',
         '<script id="app-data-json" type="application/json">',
         "navigator.serviceWorker.register(swUrl",
@@ -81,16 +82,20 @@ TEXT_REQUIRED = {
 
 TEXT_FORBIDDEN = {
     "index.html": [
+        "script-src 'self' 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
         '<script type="module" src="/src/entry.js"></script>',
     ],
     "aaz-index.html": [
         "__APP_DATA_JSON__",
         "__APP_SCRIPT__",
+        "__CSP_SCRIPT_HASHES__",
+        "script-src 'self' 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
     ],
     "v3_template.html": [
         "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js",
+        "script-src 'self' 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
     ],
     "sw.js": [
@@ -107,6 +112,8 @@ TEXT_FORBIDDEN = {
 NODE_CHECK_FILES = [
     "v3_app.js",
     "scripts/build_aaz_index.mjs",
+    "scripts/check_live_deploy.mjs",
+    "scripts/check_lighthouse_a11y.mjs",
     "scripts/dev/static-server.mjs",
     "scripts/viz/build-viz-cache.js",
     "scripts/viz/viz-state.js",

--- a/scripts/build_aaz_index.mjs
+++ b/scripts/build_aaz_index.mjs
@@ -49,15 +49,31 @@ function escapeJsonForHtmlScript(jsonText) {
     .replaceAll('<!--', '<\\!--');
 }
 
+function cspSha256(text) {
+  const browserScriptText = String(text || '').replace(/\r\n?/g, '\n');
+  return `'sha256-${createHash('sha256').update(browserScriptText, 'utf8').digest('base64')}'`;
+}
+
+function inlineScriptHashes(html) {
+  const hashes = [];
+  const scriptRe = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
+  for (const match of html.matchAll(scriptRe)) {
+    hashes.push(cspSha256(match[1]));
+  }
+  return hashes;
+}
+
 const args = parseArgs(process.argv.slice(2));
 const dataText = canonicalJsonText(args.data);
 const templateText = readFileSync(args.template, 'utf8');
 let jsText = readFileSync(args.js, 'utf8');
 const buildId = args.buildId.trim() || computeBuildId(dataText, jsText, templateText);
 jsText = jsText.replaceAll('__APP_BUILD_ID__', buildId);
-const html = templateText
+let html = templateText
   .split('__APP_DATA_JSON__').join(escapeJsonForHtmlScript(dataText))
   .split('__APP_SCRIPT__').join(jsText);
+const scriptHashes = inlineScriptHashes(html);
+html = html.split('__CSP_SCRIPT_HASHES__').join(scriptHashes.join(' '));
 
 writeFileSync(args.out, `\uFEFF${html}`, 'utf8');
 console.log(`OK: built ${join(process.cwd(), args.out)} (build_id=${buildId})`);

--- a/scripts/check_live_deploy.mjs
+++ b/scripts/check_live_deploy.mjs
@@ -66,6 +66,8 @@ async function runStaticChecks() {
     assert(text.includes('application/ld+json'), 'index.html is missing JSON-LD');
     assert(text.includes('rel="canonical"'), 'index.html is missing canonical link');
     assert(text.includes('href="./aaz-index.html#v4/home/home"'), 'index.html is missing app entry route');
+    assert(text.includes("script-src 'self' 'sha256-"), 'index.html script CSP is missing inline script hash');
+    assert(!text.includes("script-src 'self' 'unsafe-inline'"), 'index.html script CSP still allows unsafe-inline');
   });
 
   await checkText('aaz-index.html', (text) => {
@@ -73,7 +75,10 @@ async function runStaticChecks() {
     assert(text.includes('href="./vendor/leaflet.css"'), 'aaz-index.html is missing local Leaflet CSS');
     assert(text.includes('src="./vendor/leaflet.js"'), 'aaz-index.html is missing local Leaflet JS');
     assert(text.includes('navigator.serviceWorker.register(swUrl'), 'aaz-index.html is missing service-worker registration');
+    assert(text.includes("script-src 'self' 'sha256-"), 'aaz-index.html script CSP is missing inline script hashes');
     assert(!text.includes('__APP_DATA_JSON__'), 'aaz-index.html still contains an app data placeholder');
+    assert(!text.includes('__CSP_SCRIPT_HASHES__'), 'aaz-index.html still contains a CSP hash placeholder');
+    assert(!text.includes("script-src 'self' 'unsafe-inline'"), 'aaz-index.html script CSP still allows unsafe-inline');
   });
 
   await checkText('manifest.webmanifest', (text) => {

--- a/scripts/check_security_policy.mjs
+++ b/scripts/check_security_policy.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -45,18 +46,67 @@ function assertBlankLinksAreIsolated(file, text) {
   }
 }
 
+function contentSecurityPolicy(text) {
+  const cspMeta = [...text.matchAll(/<meta\b[^>]*>/gi)]
+    .map((match) => match[0])
+    .find((tag) => /\bhttp-equiv=["']Content-Security-Policy["']/i.test(tag));
+  if (!cspMeta) {
+    return '';
+  }
+  return cspMeta.match(/\bcontent="([^"]*)"/i)?.[1]
+    || cspMeta.match(/\bcontent='([^']*)'/i)?.[1]
+    || '';
+}
+
+function cspSha256(text) {
+  const browserScriptText = String(text || '').replace(/\r\n?/g, '\n');
+  return `'sha256-${createHash('sha256').update(browserScriptText, 'utf8').digest('base64')}'`;
+}
+
+function inlineScriptHashes(text) {
+  return [...text.matchAll(/<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi)]
+    .map((match) => cspSha256(match[1]));
+}
+
+function assertScriptCspDoesNotAllowUnsafeInline(file, text) {
+  const csp = contentSecurityPolicy(text);
+  const scriptSrc = csp.split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith('script-src ')) || '';
+  if (!scriptSrc) {
+    fail(`${file} is missing script-src in CSP`);
+    return;
+  }
+  if (scriptSrc.includes("'unsafe-inline'")) {
+    fail(`${file} script-src still allows 'unsafe-inline'`);
+  }
+  if (!scriptSrc.includes("'self'")) {
+    fail(`${file} script-src must include 'self' for local runtime assets`);
+  }
+}
+
+function assertInlineScriptHashesAllowed(file, text) {
+  const csp = contentSecurityPolicy(text);
+  for (const hash of inlineScriptHashes(text)) {
+    if (!csp.includes(hash)) {
+      fail(`${file} CSP is missing inline script hash: ${hash}`);
+    }
+  }
+}
+
 const htmlFiles = ['index.html', 'v3_template.html', 'aaz-index.html'];
 for (const file of htmlFiles) {
   const text = read(file);
   assertNoRemoteScriptSrc(file, text);
   assertBlankLinksAreIsolated(file, text);
+  assertScriptCspDoesNotAllowUnsafeInline(file, text);
   assertExcludes(file, text, 'unpkg.com');
   assertExcludes(file, text, 'cdn.jsdelivr.net');
 }
 
 const template = read('v3_template.html');
 assertIncludes('v3_template.html', template, "default-src 'self'");
-assertIncludes('v3_template.html', template, "script-src 'self' 'unsafe-inline'");
+assertIncludes('v3_template.html', template, "script-src 'self' __CSP_SCRIPT_HASHES__");
 assertIncludes('v3_template.html', template, "worker-src 'self' blob:");
 assertIncludes('v3_template.html', template, "object-src 'none'");
 assertIncludes('v3_template.html', template, "base-uri 'self'");
@@ -64,7 +114,15 @@ assertIncludes('v3_template.html', template, "form-action 'self'");
 assertIncludes('v3_template.html', template, '<script src="./vendor/leaflet.js"></script>');
 assertIncludes('v3_template.html', template, '<link rel="stylesheet" href="./vendor/leaflet.css">');
 assertExcludes('v3_template.html', template, 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js');
-assertExcludes('v3_template.html', template, "script-src 'self' 'unsafe-inline' https://unpkg.com");
+
+const landing = read('index.html');
+assertIncludes('index.html', landing, "script-src 'self' 'sha256-");
+assertInlineScriptHashesAllowed('index.html', landing);
+
+const appHtml = read('aaz-index.html');
+assertIncludes('aaz-index.html', appHtml, "script-src 'self' 'sha256-");
+assertExcludes('aaz-index.html', appHtml, '__CSP_SCRIPT_HASHES__');
+assertInlineScriptHashesAllowed('aaz-index.html', appHtml);
 
 for (const file of ['sw.js', 'service-worker.js']) {
   const text = read(file);

--- a/v3_template.html
+++ b/v3_template.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https:; font-src 'self' data: https:; frame-src https:; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' __CSP_SCRIPT_HASHES__; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https:; font-src 'self' data: https:; frame-src https:; object-src 'none'; base-uri 'self'; form-action 'self'">
 <meta name="theme-color" content="#5a3818">
 <meta name="color-scheme" content="light">
 <meta name="application-name" content="BookIndex">


### PR DESCRIPTION
## Summary

- Replace `script-src 'unsafe-inline'` with SHA-256 hashes on the landing page and generated standalone app shell.
- Generate browser-normalized inline script hashes during `aaz-index.html` builds, including the embedded app data and runtime script.
- Extend static, runtime, and post-deploy checks so script CSP regressions and missing hashes fail automatically.

## Why

The previous CSP still allowed all inline scripts. This keeps the standalone architecture but narrows script execution to the exact inline blocks produced by the build.

## Validation

- `npm run build:vite && npm run build`
- `npm run check:security`
- `npm run check:security:static`
- `npm run check:perf`
- `python runtime_test.py`
- `python scripts/check_encoding.py`
- `npm run typecheck`
- `npm run check:js`
- `npm run check:ui`
- `npm run check:e2e` (103 passed)
- local `BOOKINDEX_BASE_URL=http://127.0.0.1:4174/ npm run check:postdeploy`

Note: `style-src 'unsafe-inline'` remains intentionally, because the current UI still relies on inline style attributes and generated style blocks.