### PR TITLE
[codex] Harden style CSP hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Raised the axe accessibility gate to require zero critical and zero serious violations on audited routes.
 - Darkened muted helper text in the app shell so route metadata, index summary chips, chapter labels and KWIC controls meet contrast requirements.
 - Replaced script CSP `unsafe-inline` with build-generated SHA-256 hashes for the landing page and standalone app shell.
+- Replaced broad style CSP `unsafe-inline` with build-generated SHA-256 hashes for inline style blocks while isolating legacy dynamic style attributes under `style-src-attr`.
 - Opted GitHub workflows into the Node 24 JavaScript action runtime ahead of the June 2026 migration.
 
 ## [2.2.0] - 2026-05-17

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 *   **Проверка типов**: `npm run typecheck`
 *   **Полная E2E-проверка**: `npm run check`
 *   **Security guard**: `npm run check:security && npm run check:security:static`
-*   **CSP hardening**: inline scripts use SHA-256 CSP hashes generated at build time; the static and post-deploy checks fail if `script-src` regresses to `unsafe-inline`.
+*   **CSP hardening**: inline scripts and style blocks use SHA-256 CSP hashes generated at build time; the static and post-deploy checks fail if `script-src` or broad `style-src` regress to `unsafe-inline`.
 *   **Performance budget**: `npm run check:perf`
 *   **Post-deploy gates**: `npm run check:postdeploy` проверяет live GitHub Pages, Lighthouse и axe accessibility (`0` critical / `0` serious).
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'sha256-ZWmIY/3FP/2NF9G4n7qGWjNRrpHRKm0b5Qm4gQ6MhT8='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'sha256-ZWmIY/3FP/2NF9G4n7qGWjNRrpHRKm0b5Qm4gQ6MhT8='; style-src 'self' 'sha256-Mqd5vXwiOvxQCPWYW9bBIKeb7VT6VpM6CZ2GzOOUwRI='; style-src-elem 'self' 'sha256-Mqd5vXwiOvxQCPWYW9bBIKeb7VT6VpM6CZ2GzOOUwRI='; style-src-attr 'none'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" />
   <meta name="description" content="Зализнякиада: вводная страница к BookIndex, сопроводительному сайту к книге А. А. Зализняка «Из жизни слов и языков»." />
   <meta name="robots" content="index, follow, max-image-preview:large" />
   <meta name="theme-color" content="#5a3818" />

--- a/runtime_test.py
+++ b/runtime_test.py
@@ -33,6 +33,9 @@ TEXT_REQUIRED = {
         "Content-Security-Policy",
         "default-src 'self'",
         "script-src 'self' 'sha256-",
+        "style-src 'self' 'sha256-",
+        "style-src-elem 'self' 'sha256-",
+        "style-src-attr 'none'",
         'rel="manifest" href="./manifest.webmanifest"',
         'rel="canonical" href="https://gasyoun.github.io/BookIndex/index.html"',
         'property="og:image"',
@@ -43,6 +46,9 @@ TEXT_REQUIRED = {
         "Content-Security-Policy",
         "default-src 'self'",
         "script-src 'self' 'sha256-",
+        "style-src 'self' 'sha256-",
+        "style-src-elem 'self' 'sha256-",
+        "style-src-attr 'unsafe-inline'",
         'rel="manifest" href="./manifest.webmanifest"',
         '<script id="app-data-json" type="application/json">',
         "navigator.serviceWorker.register(swUrl",
@@ -83,6 +89,7 @@ TEXT_REQUIRED = {
 TEXT_FORBIDDEN = {
     "index.html": [
         "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
         '<script type="module" src="/src/entry.js"></script>',
     ],
@@ -90,12 +97,15 @@ TEXT_FORBIDDEN = {
         "__APP_DATA_JSON__",
         "__APP_SCRIPT__",
         "__CSP_SCRIPT_HASHES__",
+        "__CSP_STYLE_HASHES__",
         "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
     ],
     "v3_template.html": [
         "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js",
         "script-src 'self' 'unsafe-inline'",
+        "style-src 'self' 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
     ],
     "sw.js": [

--- a/scripts/build_aaz_index.mjs
+++ b/scripts/build_aaz_index.mjs
@@ -50,14 +50,23 @@ function escapeJsonForHtmlScript(jsonText) {
 }
 
 function cspSha256(text) {
-  const browserScriptText = String(text || '').replace(/\r\n?/g, '\n');
-  return `'sha256-${createHash('sha256').update(browserScriptText, 'utf8').digest('base64')}'`;
+  const browserInlineText = String(text || '').replace(/\r\n?/g, '\n');
+  return `'sha256-${createHash('sha256').update(browserInlineText, 'utf8').digest('base64')}'`;
 }
 
 function inlineScriptHashes(html) {
   const hashes = [];
   const scriptRe = /<script\b(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
   for (const match of html.matchAll(scriptRe)) {
+    hashes.push(cspSha256(match[1]));
+  }
+  return hashes;
+}
+
+function inlineStyleHashes(html) {
+  const hashes = [];
+  const styleRe = /<style\b[^>]*>([\s\S]*?)<\/style>/gi;
+  for (const match of html.matchAll(styleRe)) {
     hashes.push(cspSha256(match[1]));
   }
   return hashes;
@@ -73,7 +82,9 @@ let html = templateText
   .split('__APP_DATA_JSON__').join(escapeJsonForHtmlScript(dataText))
   .split('__APP_SCRIPT__').join(jsText);
 const scriptHashes = inlineScriptHashes(html);
+const styleHashes = inlineStyleHashes(html);
 html = html.split('__CSP_SCRIPT_HASHES__').join(scriptHashes.join(' '));
+html = html.split('__CSP_STYLE_HASHES__').join(styleHashes.join(' '));
 
 writeFileSync(args.out, `\uFEFF${html}`, 'utf8');
 console.log(`OK: built ${join(process.cwd(), args.out)} (build_id=${buildId})`);

--- a/scripts/check_live_deploy.mjs
+++ b/scripts/check_live_deploy.mjs
@@ -68,6 +68,9 @@ async function runStaticChecks() {
     assert(text.includes('href="./aaz-index.html#v4/home/home"'), 'index.html is missing app entry route');
     assert(text.includes("script-src 'self' 'sha256-"), 'index.html script CSP is missing inline script hash');
     assert(!text.includes("script-src 'self' 'unsafe-inline'"), 'index.html script CSP still allows unsafe-inline');
+    assert(text.includes("style-src 'self' 'sha256-"), 'index.html style CSP is missing inline style hash');
+    assert(text.includes("style-src-elem 'self' 'sha256-"), 'index.html style-src-elem is missing inline style hash');
+    assert(!text.includes("style-src 'self' 'unsafe-inline'"), 'index.html style CSP still allows broad unsafe-inline');
   });
 
   await checkText('aaz-index.html', (text) => {
@@ -76,9 +79,13 @@ async function runStaticChecks() {
     assert(text.includes('src="./vendor/leaflet.js"'), 'aaz-index.html is missing local Leaflet JS');
     assert(text.includes('navigator.serviceWorker.register(swUrl'), 'aaz-index.html is missing service-worker registration');
     assert(text.includes("script-src 'self' 'sha256-"), 'aaz-index.html script CSP is missing inline script hashes');
+    assert(text.includes("style-src 'self' 'sha256-"), 'aaz-index.html style CSP is missing inline style hash');
+    assert(text.includes("style-src-elem 'self' 'sha256-"), 'aaz-index.html style-src-elem is missing inline style hash');
     assert(!text.includes('__APP_DATA_JSON__'), 'aaz-index.html still contains an app data placeholder');
     assert(!text.includes('__CSP_SCRIPT_HASHES__'), 'aaz-index.html still contains a CSP hash placeholder');
+    assert(!text.includes('__CSP_STYLE_HASHES__'), 'aaz-index.html still contains a CSP style hash placeholder');
     assert(!text.includes("script-src 'self' 'unsafe-inline'"), 'aaz-index.html script CSP still allows unsafe-inline');
+    assert(!text.includes("style-src 'self' 'unsafe-inline'"), 'aaz-index.html style CSP still allows broad unsafe-inline');
   });
 
   await checkText('manifest.webmanifest', (text) => {

--- a/scripts/check_security_policy.mjs
+++ b/scripts/check_security_policy.mjs
@@ -59,8 +59,14 @@ function contentSecurityPolicy(text) {
 }
 
 function cspSha256(text) {
-  const browserScriptText = String(text || '').replace(/\r\n?/g, '\n');
-  return `'sha256-${createHash('sha256').update(browserScriptText, 'utf8').digest('base64')}'`;
+  const browserInlineText = String(text || '').replace(/\r\n?/g, '\n');
+  return `'sha256-${createHash('sha256').update(browserInlineText, 'utf8').digest('base64')}'`;
+}
+
+function cspDirective(csp, name) {
+  return csp.split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(`${name} `)) || '';
 }
 
 function inlineScriptHashes(text) {
@@ -68,11 +74,14 @@ function inlineScriptHashes(text) {
     .map((match) => cspSha256(match[1]));
 }
 
+function inlineStyleHashes(text) {
+  return [...text.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)]
+    .map((match) => cspSha256(match[1]));
+}
+
 function assertScriptCspDoesNotAllowUnsafeInline(file, text) {
   const csp = contentSecurityPolicy(text);
-  const scriptSrc = csp.split(';')
-    .map((part) => part.trim())
-    .find((part) => part.startsWith('script-src ')) || '';
+  const scriptSrc = cspDirective(csp, 'script-src');
   if (!scriptSrc) {
     fail(`${file} is missing script-src in CSP`);
     return;
@@ -85,11 +94,41 @@ function assertScriptCspDoesNotAllowUnsafeInline(file, text) {
   }
 }
 
+function assertStyleCspDoesNotAllowBroadUnsafeInline(file, text) {
+  const csp = contentSecurityPolicy(text);
+  const styleSrc = cspDirective(csp, 'style-src');
+  const styleSrcElem = cspDirective(csp, 'style-src-elem');
+  if (!styleSrc) {
+    fail(`${file} is missing style-src in CSP`);
+    return;
+  }
+  if (!styleSrcElem) {
+    fail(`${file} is missing style-src-elem in CSP`);
+  }
+  for (const directive of [styleSrc, styleSrcElem].filter(Boolean)) {
+    if (directive.includes("'unsafe-inline'")) {
+      fail(`${file} ${directive.split(/\s+/)[0]} still allows broad 'unsafe-inline'`);
+    }
+    if (!directive.includes("'self'")) {
+      fail(`${file} ${directive.split(/\s+/)[0]} must include 'self' for local CSS assets`);
+    }
+  }
+}
+
 function assertInlineScriptHashesAllowed(file, text) {
   const csp = contentSecurityPolicy(text);
   for (const hash of inlineScriptHashes(text)) {
     if (!csp.includes(hash)) {
       fail(`${file} CSP is missing inline script hash: ${hash}`);
+    }
+  }
+}
+
+function assertInlineStyleHashesAllowed(file, text) {
+  const csp = contentSecurityPolicy(text);
+  for (const hash of inlineStyleHashes(text)) {
+    if (!csp.includes(hash)) {
+      fail(`${file} CSP is missing inline style hash: ${hash}`);
     }
   }
 }
@@ -100,6 +139,7 @@ for (const file of htmlFiles) {
   assertNoRemoteScriptSrc(file, text);
   assertBlankLinksAreIsolated(file, text);
   assertScriptCspDoesNotAllowUnsafeInline(file, text);
+  assertStyleCspDoesNotAllowBroadUnsafeInline(file, text);
   assertExcludes(file, text, 'unpkg.com');
   assertExcludes(file, text, 'cdn.jsdelivr.net');
 }
@@ -107,6 +147,9 @@ for (const file of htmlFiles) {
 const template = read('v3_template.html');
 assertIncludes('v3_template.html', template, "default-src 'self'");
 assertIncludes('v3_template.html', template, "script-src 'self' __CSP_SCRIPT_HASHES__");
+assertIncludes('v3_template.html', template, "style-src 'self' __CSP_STYLE_HASHES__");
+assertIncludes('v3_template.html', template, "style-src-elem 'self' __CSP_STYLE_HASHES__");
+assertIncludes('v3_template.html', template, "style-src-attr 'unsafe-inline'");
 assertIncludes('v3_template.html', template, "worker-src 'self' blob:");
 assertIncludes('v3_template.html', template, "object-src 'none'");
 assertIncludes('v3_template.html', template, "base-uri 'self'");
@@ -117,12 +160,21 @@ assertExcludes('v3_template.html', template, 'https://unpkg.com/leaflet@1.9.4/di
 
 const landing = read('index.html');
 assertIncludes('index.html', landing, "script-src 'self' 'sha256-");
+assertIncludes('index.html', landing, "style-src 'self' 'sha256-");
+assertIncludes('index.html', landing, "style-src-elem 'self' 'sha256-");
+assertIncludes('index.html', landing, "style-src-attr 'none'");
 assertInlineScriptHashesAllowed('index.html', landing);
+assertInlineStyleHashesAllowed('index.html', landing);
 
 const appHtml = read('aaz-index.html');
 assertIncludes('aaz-index.html', appHtml, "script-src 'self' 'sha256-");
+assertIncludes('aaz-index.html', appHtml, "style-src 'self' 'sha256-");
+assertIncludes('aaz-index.html', appHtml, "style-src-elem 'self' 'sha256-");
+assertIncludes('aaz-index.html', appHtml, "style-src-attr 'unsafe-inline'");
 assertExcludes('aaz-index.html', appHtml, '__CSP_SCRIPT_HASHES__');
+assertExcludes('aaz-index.html', appHtml, '__CSP_STYLE_HASHES__');
 assertInlineScriptHashesAllowed('aaz-index.html', appHtml);
+assertInlineStyleHashesAllowed('aaz-index.html', appHtml);
 
 for (const file of ['sw.js', 'service-worker.js']) {
   const text = read(file);

--- a/v3_template.html
+++ b/v3_template.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' __CSP_SCRIPT_HASHES__; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https:; font-src 'self' data: https:; frame-src https:; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' __CSP_SCRIPT_HASHES__; worker-src 'self' blob:; style-src 'self' __CSP_STYLE_HASHES__; style-src-elem 'self' __CSP_STYLE_HASHES__; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https:; font-src 'self' data: https:; frame-src https:; object-src 'none'; base-uri 'self'; form-action 'self'">
 <meta name="theme-color" content="#5a3818">
 <meta name="color-scheme" content="light">
 <meta name="application-name" content="BookIndex">


### PR DESCRIPTION
## Summary

- Replace broad `style-src 'unsafe-inline'` with SHA-256 hashes for inline style blocks on the landing page and standalone app shell.
- Generate style CSP hashes at build time alongside the existing script hashes.
- Keep legacy runtime style attributes isolated under `style-src-attr 'unsafe-inline'` for the app shell, while the landing page forbids style attributes with `style-src-attr 'none'`.
- Extend static, runtime, and post-deploy checks so broad style CSP regressions and missing style hashes fail automatically.

## Why

The previous script CSP hardening still left style blocks covered by broad `style-src 'unsafe-inline'`. This narrows inline CSS execution without breaking the current standalone UI, which still uses dynamic style attributes in a few places.

## Validation

- `npm run build:vite && npm run build`
- targeted local browser smoke with no CSP console/page errors
- `npm run check:security`
- `npm run check:security:static`
- `npm run check:perf`
- `python runtime_test.py`
- `python scripts/check_encoding.py`
- `npm run typecheck`
- `npm run check:js`
- `npm run check:ui`
- `npm run check:e2e` (103 passed)
- local `BOOKINDEX_BASE_URL=http://127.0.0.1:4174/ npm run check:postdeploy`

Note: the app still permits `style-src-attr 'unsafe-inline'` because existing runtime behavior uses inline style attributes and DOM style assignments. The broad `style-src` and `style-src-elem` directives no longer allow `unsafe-inline`.