### PR TITLE
[codex] Harden inline style CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 - Raised the axe accessibility gate to require zero critical and zero serious violations on audited routes.
 - Darkened muted helper text in the app shell so route metadata, index summary chips, chapter labels and KWIC controls meet contrast requirements.
 - Replaced script CSP `unsafe-inline` with build-generated SHA-256 hashes for the landing page and standalone app shell.
-- Replaced broad style CSP `unsafe-inline` with build-generated SHA-256 hashes for inline style blocks while isolating legacy dynamic style attributes under `style-src-attr`.
+- Replaced broad style CSP `unsafe-inline` with build-generated SHA-256 hashes for inline style blocks.
+- Removed the remaining `style-src-attr 'unsafe-inline'` exception by moving runtime style attributes to `data-*` driven DOM style updates.
 - Opted GitHub workflows into the Node 24 JavaScript action runtime ahead of the June 2026 migration.
 
 ## [2.2.0] - 2026-05-17

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 *   **Проверка типов**: `npm run typecheck`
 *   **Полная E2E-проверка**: `npm run check`
 *   **Security guard**: `npm run check:security && npm run check:security:static`
-*   **CSP hardening**: inline scripts and style blocks use SHA-256 CSP hashes generated at build time; the static and post-deploy checks fail if `script-src` or broad `style-src` regress to `unsafe-inline`.
+*   **CSP hardening**: inline scripts and style blocks use SHA-256 CSP hashes generated at build time; inline style attributes are denied, and the static/post-deploy checks fail if CSP regresses to `unsafe-inline`.
 *   **Performance budget**: `npm run check:perf`
 *   **Post-deploy gates**: `npm run check:postdeploy` проверяет live GitHub Pages, Lighthouse и axe accessibility (`0` critical / `0` serious).
 

--- a/runtime_test.py
+++ b/runtime_test.py
@@ -48,7 +48,7 @@ TEXT_REQUIRED = {
         "script-src 'self' 'sha256-",
         "style-src 'self' 'sha256-",
         "style-src-elem 'self' 'sha256-",
-        "style-src-attr 'unsafe-inline'",
+        "style-src-attr 'none'",
         'rel="manifest" href="./manifest.webmanifest"',
         '<script id="app-data-json" type="application/json">',
         "navigator.serviceWorker.register(swUrl",
@@ -100,12 +100,14 @@ TEXT_FORBIDDEN = {
         "__CSP_STYLE_HASHES__",
         "script-src 'self' 'unsafe-inline'",
         "style-src 'self' 'unsafe-inline'",
+        "style-src-attr 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
     ],
     "v3_template.html": [
         "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js",
         "script-src 'self' 'unsafe-inline'",
         "style-src 'self' 'unsafe-inline'",
+        "style-src-attr 'unsafe-inline'",
         "script-src 'self' 'unsafe-inline' https://unpkg.com",
     ],
     "sw.js": [

--- a/scripts/check_inline_styles.mjs
+++ b/scripts/check_inline_styles.mjs
@@ -1,48 +1,31 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 
-const file = 'v3_app.js';
-const maxInlineStyles = 11;
-const allowedInlineStylePatterns = [
-  /class="bar-fill"[^`]*style="width:\$\{pct\}%"/,
-  /class="epoch-card-head" style="--epoch-color:\$\{epochColor\};"/,
-  /class="legend-dot" style="background:\$\{safeColor\(FAMILY_COLORS\[fam\], '#888'\)\}"/,
-  /id="home-declarative-root"[^`]*style="--home-decl-padding:\$\{viewModel\.homeInnerPadding\};"/,
-  /class="home-facts" style="--home-facts-space:\$\{viewModel\.compactHome \? 10 : 14\}px;--home-facts-line-height:\$\{viewModel\.compactHome \? 1\.55 : 1\.7\};"/,
-  /id="home-featured-quote-decl"[^`]*style="--home-featured-padding:\$\{viewModel\.compactHome \? 8 : 10\}px;"/,
-  /class="home-panel-inner" style="--home-inner-padding:\$\{homeInnerPadding\};"/,
-  /class="home-facts" style="--home-facts-space:\$\{compactHome \? 10 : 14\}px;--home-facts-line-height:\$\{compactHome \? 1\.55 : 1\.7\};/,
-  /id="home-featured-quote"[^`]*style="--home-featured-padding:\$\{compactHome \? 8 : 10\}px;"/,
-  /class="scholar-recon-grid" style="--scholar-recon-columns:\$\{reconstructionColumns\};"/,
-  /class="scholar-compare-cell" style="\$\{bg\}"/,
+const files = [
+  'v3_app.js',
+  ...readdirSync(path.join(process.cwd(), 'scripts', 'viz'))
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => path.join('scripts', 'viz', name)),
 ];
-const source = readFileSync(file, 'utf8');
-const lines = source.split(/\r?\n/);
+const maxInlineStyles = 0;
 const matches = [];
 
-for (let i = 0; i < lines.length; i += 1) {
-  if (/\sstyle="/.test(lines[i])) {
-    matches.push({ line: i + 1, text: lines[i].trim() });
+for (const file of files) {
+  const source = readFileSync(file, 'utf8');
+  const lines = source.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/\sstyle=["']/.test(lines[i])) {
+      matches.push({ file, line: i + 1, text: lines[i].trim() });
+    }
   }
 }
 
 if (matches.length > maxInlineStyles) {
-  console.error(`[inline-styles] FAIL: ${file} has ${matches.length} inline style attributes; max is ${maxInlineStyles}.`);
+  console.error(`[inline-styles] FAIL: checked files have ${matches.length} inline style attributes; max is ${maxInlineStyles}.`);
   for (const match of matches) {
-    console.error(`  ${match.line}: ${match.text}`);
+    console.error(`  ${match.file}:${match.line}: ${match.text}`);
   }
   process.exit(1);
 }
 
-const unexpected = matches.filter((match) => (
-  !allowedInlineStylePatterns.some((pattern) => pattern.test(match.text))
-));
-
-if (unexpected.length) {
-  console.error(`[inline-styles] FAIL: ${file} has unexpected inline style attributes.`);
-  for (const match of unexpected) {
-    console.error(`  ${match.line}: ${match.text}`);
-  }
-  process.exit(1);
-}
-
-console.log(`[inline-styles] OK: ${file} has ${matches.length}/${maxInlineStyles} inline style attributes.`);
+console.log(`[inline-styles] OK: checked ${files.length} files with ${matches.length}/${maxInlineStyles} inline style attributes.`);

--- a/scripts/check_live_deploy.mjs
+++ b/scripts/check_live_deploy.mjs
@@ -70,7 +70,9 @@ async function runStaticChecks() {
     assert(!text.includes("script-src 'self' 'unsafe-inline'"), 'index.html script CSP still allows unsafe-inline');
     assert(text.includes("style-src 'self' 'sha256-"), 'index.html style CSP is missing inline style hash');
     assert(text.includes("style-src-elem 'self' 'sha256-"), 'index.html style-src-elem is missing inline style hash');
+    assert(text.includes("style-src-attr 'none'"), 'index.html style-src-attr must deny inline style attributes');
     assert(!text.includes("style-src 'self' 'unsafe-inline'"), 'index.html style CSP still allows broad unsafe-inline');
+    assert(!text.includes("style-src-attr 'unsafe-inline'"), 'index.html style-src-attr still allows unsafe-inline');
   });
 
   await checkText('aaz-index.html', (text) => {
@@ -81,11 +83,13 @@ async function runStaticChecks() {
     assert(text.includes("script-src 'self' 'sha256-"), 'aaz-index.html script CSP is missing inline script hashes');
     assert(text.includes("style-src 'self' 'sha256-"), 'aaz-index.html style CSP is missing inline style hash');
     assert(text.includes("style-src-elem 'self' 'sha256-"), 'aaz-index.html style-src-elem is missing inline style hash');
+    assert(text.includes("style-src-attr 'none'"), 'aaz-index.html style-src-attr must deny inline style attributes');
     assert(!text.includes('__APP_DATA_JSON__'), 'aaz-index.html still contains an app data placeholder');
     assert(!text.includes('__CSP_SCRIPT_HASHES__'), 'aaz-index.html still contains a CSP hash placeholder');
     assert(!text.includes('__CSP_STYLE_HASHES__'), 'aaz-index.html still contains a CSP style hash placeholder');
     assert(!text.includes("script-src 'self' 'unsafe-inline'"), 'aaz-index.html script CSP still allows unsafe-inline');
     assert(!text.includes("style-src 'self' 'unsafe-inline'"), 'aaz-index.html style CSP still allows broad unsafe-inline');
+    assert(!text.includes("style-src-attr 'unsafe-inline'"), 'aaz-index.html style-src-attr still allows unsafe-inline');
   });
 
   await checkText('manifest.webmanifest', (text) => {

--- a/scripts/check_security_policy.mjs
+++ b/scripts/check_security_policy.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
 const root = process.cwd();
@@ -98,12 +98,16 @@ function assertStyleCspDoesNotAllowBroadUnsafeInline(file, text) {
   const csp = contentSecurityPolicy(text);
   const styleSrc = cspDirective(csp, 'style-src');
   const styleSrcElem = cspDirective(csp, 'style-src-elem');
+  const styleSrcAttr = cspDirective(csp, 'style-src-attr');
   if (!styleSrc) {
     fail(`${file} is missing style-src in CSP`);
     return;
   }
   if (!styleSrcElem) {
     fail(`${file} is missing style-src-elem in CSP`);
+  }
+  if (!styleSrcAttr) {
+    fail(`${file} is missing style-src-attr in CSP`);
   }
   for (const directive of [styleSrc, styleSrcElem].filter(Boolean)) {
     if (directive.includes("'unsafe-inline'")) {
@@ -112,6 +116,28 @@ function assertStyleCspDoesNotAllowBroadUnsafeInline(file, text) {
     if (!directive.includes("'self'")) {
       fail(`${file} ${directive.split(/\s+/)[0]} must include 'self' for local CSS assets`);
     }
+  }
+  if (styleSrcAttr && styleSrcAttr.includes("'unsafe-inline'")) {
+    fail(`${file} style-src-attr still allows 'unsafe-inline'`);
+  }
+  if (styleSrcAttr && !styleSrcAttr.includes("'none'")) {
+    fail(`${file} style-src-attr must be 'none'`);
+  }
+}
+
+function assertNoInlineStyleAttributes(file, text) {
+  const inlineStyles = [...text.matchAll(/\sstyle=["'][^"']*["']/gi)];
+  if (inlineStyles.length) {
+    fail(`${file} contains inline style attributes`);
+  }
+}
+
+function assertNoRuntimeStyleBlocks(file, text) {
+  if (/<style\b/i.test(text)) {
+    fail(`${file} injects runtime <style> blocks`);
+  }
+  if (/createElement\(["']style["']\)/i.test(text)) {
+    fail(`${file} creates runtime style elements`);
   }
 }
 
@@ -140,8 +166,21 @@ for (const file of htmlFiles) {
   assertBlankLinksAreIsolated(file, text);
   assertScriptCspDoesNotAllowUnsafeInline(file, text);
   assertStyleCspDoesNotAllowBroadUnsafeInline(file, text);
+  assertNoInlineStyleAttributes(file, text);
   assertExcludes(file, text, 'unpkg.com');
   assertExcludes(file, text, 'cdn.jsdelivr.net');
+}
+
+const scriptFiles = [
+  'v3_app.js',
+  ...readdirSync(path.join(root, 'scripts', 'viz'))
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => path.join('scripts', 'viz', name)),
+];
+for (const file of scriptFiles) {
+  const text = read(file);
+  assertNoInlineStyleAttributes(file, text);
+  assertNoRuntimeStyleBlocks(file, text);
 }
 
 const template = read('v3_template.html');
@@ -149,7 +188,7 @@ assertIncludes('v3_template.html', template, "default-src 'self'");
 assertIncludes('v3_template.html', template, "script-src 'self' __CSP_SCRIPT_HASHES__");
 assertIncludes('v3_template.html', template, "style-src 'self' __CSP_STYLE_HASHES__");
 assertIncludes('v3_template.html', template, "style-src-elem 'self' __CSP_STYLE_HASHES__");
-assertIncludes('v3_template.html', template, "style-src-attr 'unsafe-inline'");
+assertIncludes('v3_template.html', template, "style-src-attr 'none'");
 assertIncludes('v3_template.html', template, "worker-src 'self' blob:");
 assertIncludes('v3_template.html', template, "object-src 'none'");
 assertIncludes('v3_template.html', template, "base-uri 'self'");
@@ -170,7 +209,7 @@ const appHtml = read('aaz-index.html');
 assertIncludes('aaz-index.html', appHtml, "script-src 'self' 'sha256-");
 assertIncludes('aaz-index.html', appHtml, "style-src 'self' 'sha256-");
 assertIncludes('aaz-index.html', appHtml, "style-src-elem 'self' 'sha256-");
-assertIncludes('aaz-index.html', appHtml, "style-src-attr 'unsafe-inline'");
+assertIncludes('aaz-index.html', appHtml, "style-src-attr 'none'");
 assertExcludes('aaz-index.html', appHtml, '__CSP_SCRIPT_HASHES__');
 assertExcludes('aaz-index.html', appHtml, '__CSP_STYLE_HASHES__');
 assertInlineScriptHashesAllowed('aaz-index.html', appHtml);

--- a/scripts/viz/comparative-timeline.js
+++ b/scripts/viz/comparative-timeline.js
@@ -18,15 +18,7 @@
 
     container.innerHTML = `
       <div class="viz-card viz-comparative-timeline">
-        <style>
-          .viz-comparative-timeline { background: #1c1b18; color: #eee; padding: 2rem; border-radius: 12px; }
-          .axis-line { stroke: rgba(255,255,255,0.2); }
-          .timeline-event { cursor: pointer; transition: 0.2s; }
-          .timeline-event:hover circle { r: 8; stroke: #80deea; }
-          .event-label { font-size: 10px; fill: #aaa; font-family: 'Inter', sans-serif; }
-          .lane-label { font-size: 12px; font-weight: 700; fill: #80deea; text-transform: uppercase; }
-        </style>
-        <h2 style="margin-top:0; color:#80deea;">Сравнительная хронология: Язык и История <span class="v-badge">v7.2</span></h2>
+        <h2 class="viz-comparative-title">Сравнительная хронология: Язык и История <span class="v-badge">v7.2</span></h2>
         <svg id="comparative-timeline-svg" width="100%" height="400"></svg>
       </div>
     `;

--- a/scripts/viz/cooccurrence-graph.js
+++ b/scripts/viz/cooccurrence-graph.js
@@ -70,8 +70,8 @@
 
     if (legend) {
       legend.innerHTML = [
-        '<span class="viz-legend-item"><span class="viz-legend-dot" style="background:var(--color-primary);"></span>имена</span>',
-        '<span class="viz-legend-item"><span class="viz-legend-dot" style="background:var(--color-gold);"></span>языки</span>',
+        '<span class="viz-legend-item"><span class="viz-legend-dot viz-legend-dot-primary"></span>имена</span>',
+        '<span class="viz-legend-item"><span class="viz-legend-dot viz-legend-dot-gold"></span>языки</span>',
       ].join('');
     }
 

--- a/scripts/viz/corpus-timeline.js
+++ b/scripts/viz/corpus-timeline.js
@@ -5,84 +5,8 @@
 
 window.VIZ_MODULES = window.VIZ_MODULES || {};
 window.VIZ_MODULES.renderCorpusTimeline = function(container, appData) {
-    if (!document.getElementById('corpus-timeline-styles')) {
-        const style = document.createElement('style');
-        style.id = 'corpus-timeline-styles';
-        style.textContent = `
-            .corpus-timeline {
-                font-family: 'Inter', system-ui, -apple-system, sans-serif;
-                color: #e0e0e0;
-                padding: 2rem;
-                max-width: 1000px;
-                margin: 0 auto;
-                background: radial-gradient(circle at top right, rgba(103, 58, 183, 0.1), transparent),
-                            radial-gradient(circle at bottom left, rgba(0, 150, 136, 0.1), transparent);
-            }
-            .timeline-header { text-align: center; margin-bottom: 4rem; }
-            .timeline-header h1 {
-                font-size: 3rem; font-weight: 800;
-                background: linear-gradient(135deg, #b388ff, #80deea);
-                -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-                margin-bottom: 0.5rem;
-            }
-            .timeline-scroll-container { position: relative; padding-left: 3rem; }
-            .timeline-track {
-                position: absolute; left: 15px; top: 0; bottom: 0; width: 4px;
-                background: linear-gradient(to bottom, #b388ff, #80deea, #b388ff);
-                border-radius: 2px; opacity: 0.3;
-            }
-            .timeline-item-wrapper {
-                position: relative; margin-bottom: 3rem; opacity: 0;
-                transform: translateY(20px); animation: fadeInSlide 0.6s forwards;
-                animation-delay: calc(var(--index) * 0.1s);
-            }
-            @keyframes fadeInSlide { to { opacity: 1; transform: translateY(0); } }
-            .timeline-dot {
-                position: absolute; left: -23px; top: 25px; width: 20px; height: 20px;
-                background: #b388ff; border: 4px solid #1a1a1a; border-radius: 50%;
-                z-index: 2; box-shadow: 0 0 15px rgba(179, 136, 255, 0.6);
-            }
-            .lecture-card {
-                background: rgba(255, 255, 255, 0.05); backdrop-filter: blur(12px);
-                border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 20px;
-                padding: 1.5rem; cursor: pointer; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-                overflow: hidden;
-            }
-            .lecture-card:hover {
-                background: rgba(255, 255, 255, 0.08); border-color: rgba(179, 136, 255, 0.4);
-                transform: translateX(10px); box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-            }
-            .card-header { display: flex; align-items: center; gap: 1.5rem; }
-            .lecture-icon {
-                font-size: 2.5rem; background: rgba(179, 136, 255, 0.1);
-                width: 60px; height: 60px; display: flex; align-items: center; justify-content: center;
-                border-radius: 15px;
-            }
-            .lecture-pages { font-size: 0.8rem; text-transform: uppercase; letter-spacing: 1px; color: #80deea; }
-            .lecture-title { font-size: 1.4rem; margin: 0.2rem 0; }
-            .card-content { margin-top: 1rem; }
-            .main-idea { font-size: 1.1rem; line-height: 1.6; color: #bbb; }
-            .details { max-height: 0; opacity: 0; transition: all 0.5s ease; overflow: hidden;}
-            .lecture-card.expanded .details { max-height: 800px; opacity: 1; margin-top: 1.5rem; }
-            .details h4 { color: #b388ff; margin-bottom: 0.5rem; }
-            .details ul { list-style: none; padding: 0; }
-            .details li { margin-bottom: 0.5rem; padding-left: 1.5rem; position: relative; }
-            .details li::before { content: '→'; position: absolute; left: 0; color: #80deea; }
-            .tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 1.5rem; }
-            .term-tag {
-                background: rgba(128, 222, 234, 0.1); border: 1px solid rgba(128, 222, 234, 0.2);
-                color: #80deea; padding: 0.3rem 0.8rem; border-radius: 20px; font-size: 0.85rem;
-                transition: all 0.2s;
-            }
-            .term-tag:hover { background: rgba(128, 222, 234, 0.2); border-color: #80deea; }
-            .card-footer { margin-top: 1rem; text-align: right; }
-            .expand-btn { background: transparent; border: none; color: #b388ff; font-size: 0.9rem; font-weight: 600; cursor: pointer; padding: 0; }
-        `;
-        document.head.appendChild(style);
-    }
-
     const lectures = appData.lectures || [];
-    
+
     const html = `
         <div class="corpus-timeline">
             <header class="timeline-header">
@@ -97,9 +21,9 @@ window.VIZ_MODULES.renderCorpusTimeline = function(container, appData) {
             </div>
         </div>
     `;
-    
+
     container.innerHTML = html;
-    
+
     // Add event listeners for interactivity
     container.querySelectorAll('.lecture-card').forEach(card => {
         card.addEventListener('click', () => {
@@ -111,9 +35,9 @@ window.VIZ_MODULES.renderCorpusTimeline = function(container, appData) {
 function renderLectureCard(lecture, index) {
     const icon = lecture.icon || '📘';
     const terms = lecture.terms || [];
-    
+
     return `
-        <div class="timeline-item-wrapper" style="--index: ${index}">
+        <div class="timeline-item-wrapper">
             <div class="timeline-dot"></div>
             <div class="lecture-card" data-index="${index}">
                 <div class="card-header">

--- a/scripts/viz/discovery-timeline.js
+++ b/scripts/viz/discovery-timeline.js
@@ -75,7 +75,7 @@
       `    <label><input type="checkbox" data-type="linguist"${activeFilters.has('linguist') ? ' checked' : ''}> linguist</label>`,
       `    <label><input type="checkbox" data-type="historical"${activeFilters.has('historical') ? ' checked' : ''}> historical</label>`,
       '  </div>',
-      '  <div class="viz-empty-state" style="display:none;">',
+      '  <div class="viz-empty-state" hidden>',
       '    <strong>Ничего не выбрано.</strong><br>Включите хотя бы один фильтр (discovery, linguist, historical).',
       '  </div>',
       '  <div class="tl-wrap tl-grid">',
@@ -86,12 +86,6 @@
     const wrap = container.querySelector('.tl-wrap');
     const empty = container.querySelector('.viz-empty-state');
     const checkboxes = Array.from(container.querySelectorAll('.viz-toolbar input[type="checkbox"]'));
-    const colorByType = {
-      discovery: 'var(--primary)',
-      linguist: safeColor(colors.linguist, '#3a6ea5'),
-      historical: safeColor(colors.historical, '#c0392b'),
-    };
-
     let pendingOpenTimer = null;
     function clearPendingOpen() {
       if (!pendingOpenTimer) return;
@@ -102,9 +96,8 @@
     for (let i = 0; i < items.length; i += 1) {
       const item = items[i];
       const card = document.createElement('article');
-      card.className = 'tl-item';
+      card.className = `tl-item tl-item-${item.type}`;
       card.dataset.type = item.type;
-      card.style.borderLeft = `4px solid ${safeColor(colorByType[item.type], '#5a3818')}`;
       card.innerHTML = [
         `<div class="tl-year">${String(item.year)}</div>`,
         `<div class="tl-label">${String(item.label || '')}</div>`,
@@ -153,7 +146,7 @@
         card.hidden = !visible;
         if (visible) visibleCount += 1;
       }
-      if (empty) empty.style.display = visibleCount ? 'none' : '';
+      if (empty) empty.hidden = !!visibleCount;
       if (typeof root.writeVizParams === 'function') {
         const filter = Object.keys(enabled).filter((type) => enabled[type]).join(',');
         root.writeVizParams({ filter });

--- a/scripts/viz/heatmap-matrix.js
+++ b/scripts/viz/heatmap-matrix.js
@@ -170,9 +170,9 @@
       '    </label>',
       '    <button type="button" id="viz-heatmap-export" class="related-link related-link-btn">Скачать SVG</button>',
       '  </div>',
-      '  <div class="viz-svg-wrap" style="position:relative;">',
+      '  <div class="viz-svg-wrap">',
       '    <svg id="viz-heatmap-svg" width="100%" height="760" viewBox="0 0 1260 760" preserveAspectRatio="xMidYMid meet"></svg>',
-      '    <div id="viz-heatmap-tooltip" class="viz-tooltip" style="display:none;position:absolute;"></div>',
+      '    <div id="viz-heatmap-tooltip" class="viz-tooltip viz-tooltip-floating" hidden></div>',
       '  </div>',
       '</div>',
     ].join('');
@@ -202,7 +202,7 @@
 
     function showTooltip(event, row) {
       if (!tooltip) return;
-      tooltip.style.display = 'block';
+      tooltip.hidden = false;
       tooltip.textContent = `Лекция ${row.chapterIndex + 1} · ${row.term} · Частота: ${row.value}`;
       const hostRect = container.getBoundingClientRect();
       const x = (event && Number.isFinite(event.clientX) ? event.clientX : hostRect.left) - hostRect.left + 8;
@@ -213,7 +213,7 @@
 
     function hideTooltip() {
       if (!tooltip) return;
-      tooltip.style.display = 'none';
+      tooltip.hidden = true;
     }
 
     function buildState(topNValue) {

--- a/scripts/viz/knowledge-web.js
+++ b/scripts/viz/knowledge-web.js
@@ -63,11 +63,11 @@
     const height = 600;
 
     container.innerHTML = `
-      <div class="viz-card" style="height:100%; display:flex; flex-direction:column; overflow:hidden;">
-        <div class="viz-toolbar" style="padding:10px; background:rgba(0,0,0,0.05);">
+      <div class="viz-card viz-card-fill">
+        <div class="viz-toolbar viz-toolbar-padded">
           <strong>Сеть знаний:</strong> Связи между главами, терминами и видеолекциями
         </div>
-        <svg id="knowledge-web-svg" width="100%" height="${height}" style="background:var(--bg);"></svg>
+        <svg id="knowledge-web-svg" class="viz-svg-bg" width="100%" height="${height}"></svg>
       </div>
     `;
 

--- a/scripts/viz/lang-chord.js
+++ b/scripts/viz/lang-chord.js
@@ -85,7 +85,7 @@
         const suffix = disabledByFreq ? ' (ниже порога)' : '';
         return [
           `<span class="viz-legend-item toggleable${inactive ? ' inactive' : ''}" data-lang="${lang}" title="${title}">`,
-          `  <span class="viz-legend-dot" style="background:${color(idx)};"></span>${lang}${suffix}`,
+          `  <span class="viz-legend-dot viz-legend-color-${idx % 22}"></span>${lang}${suffix}`,
           '</span>',
         ].join('');
       }).join('');

--- a/scripts/viz/language-tree.js
+++ b/scripts/viz/language-tree.js
@@ -32,11 +32,11 @@
     const height = 800;
     
     container.innerHTML = `
-      <div class="viz-card" style="height:100%; overflow:auto; background:var(--bg);">
-        <div class="viz-toolbar" style="padding:10px; background:rgba(0,0,0,0.05); position:sticky; top:0; z-index:10;">
+      <div class="viz-card viz-card-scroll">
+        <div class="viz-toolbar viz-toolbar-padded viz-toolbar-sticky">
           <strong>Древо языков:</strong> Генеалогическая иерархия по упоминаниям
         </div>
-        <div id="language-tree-svg-container" style="padding:20px;"></div>
+        <div id="language-tree-svg-container" class="viz-card-pad"></div>
       </div>
     `;
 

--- a/scripts/viz/map-timeline.js
+++ b/scripts/viz/map-timeline.js
@@ -76,7 +76,7 @@
     const fallback = document.createElement('div');
     fallback.className = 'viz-empty-state';
     fallback.classList.add('viz-map-fallback');
-    fallback.style.display = 'none';
+    fallback.hidden = true;
     fallback.innerHTML = '<strong>Офлайн-режим карты</strong><br>Тайлы недоступны, но маркеры и навигация работают.';
     if (canvas) canvas.appendChild(fallback);
 
@@ -90,11 +90,11 @@
     tileLayer.on('load', () => {
       tileLoaded = true;
       tileErrors = 0;
-      fallback.style.display = 'none';
+      fallback.hidden = true;
     });
     tileLayer.on('tileerror', () => {
       tileErrors += 1;
-      if (!tileLoaded && tileErrors >= 6) fallback.style.display = '';
+      if (!tileLoaded && tileErrors >= 6) fallback.hidden = false;
     });
     tileLayer.addTo(map);
 

--- a/scripts/viz/multimedia-bridge.js
+++ b/scripts/viz/multimedia-bridge.js
@@ -53,11 +53,11 @@
     const height = Math.max(600, nodes.length * 20);
 
     container.innerHTML = `
-      <div class="viz-card" style="height:100%; overflow:auto; background:var(--bg);">
-        <div class="viz-toolbar" style="padding:10px; background:rgba(0,0,0,0.05); position:sticky; top:0; z-index:10;">
+      <div class="viz-card viz-card-scroll">
+        <div class="viz-toolbar viz-toolbar-padded viz-toolbar-sticky">
           <strong>Мультимедийный мост:</strong> Связи между главами книги и видеолекциями
         </div>
-        <div id="multimedia-bridge-svg-container" style="padding:20px;"></div>
+        <div id="multimedia-bridge-svg-container" class="viz-card-pad"></div>
       </div>
     `;
 

--- a/scripts/viz/viz-semantic-graph.js
+++ b/scripts/viz/viz-semantic-graph.js
@@ -26,24 +26,14 @@
 
     container.innerHTML = `
       <div class="viz-card viz-semantic-graph">
-        <style>
-          .viz-semantic-graph { background: #1a1a1a; color: #eee; border-radius: 12px; overflow: hidden; position: relative; }
-          .viz-toolbar { position: absolute; top: 20px; left: 20px; z-index: 10; display: flex; gap: 10px; align-items: center; }
-          .viz-btn { background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2); color: #fff; padding: 5px 15px; border-radius: 20px; cursor: pointer; transition: 0.2s; font-size: 0.85rem; }
-          .viz-btn:hover { background: rgba(128, 222, 234, 0.2); border-color: #80deea; }
-          .viz-legend { position: absolute; bottom: 20px; right: 20px; background: rgba(0,0,0,0.5); padding: 10px; border-radius: 8px; font-size: 0.8rem; backdrop-filter: blur(5px); }
-          .node-glow { filter: drop-shadow(0 0 5px currentColor); }
-          .link-line { stroke-opacity: 0.2; }
-          .node-label { font-family: 'Inter', sans-serif; font-weight: 500; pointer-events: none; }
-        </style>
         <div class="viz-toolbar">
           <button class="viz-btn" id="viz-reset-zoom">Сбросить зум</button>
-          <span id="viz-graph-status" style="font-size: 0.8rem; opacity: 0.7;"></span>
+          <span id="viz-graph-status" class="viz-semantic-status"></span>
         </div>
-        <div class="viz-legend">
-          <div style="color:#80deea">● Имена</div>
-          <div style="color:#b388ff">● Языки</div>
-          <div style="color:#26a69a">● Лексика</div>
+        <div class="viz-legend viz-semantic-legend">
+          <div class="viz-semantic-legend-name">● Имена</div>
+          <div class="viz-semantic-legend-lang">● Языки</div>
+          <div class="viz-semantic-legend-lex">● Лексика</div>
         </div>
         <svg id="semantic-graph-svg" width="100%" height="700"></svg>
       </div>

--- a/scripts/viz/world-map.js
+++ b/scripts/viz/world-map.js
@@ -38,17 +38,17 @@
 
     const mapId = `viz-world-map-${Date.now()}`;
     container.innerHTML = `
-      <div class="viz-card viz-world-map-shell" style="height:100%; display:flex; flex-direction:column;">
-        <div class="viz-toolbar" style="padding:10px; display:flex; gap:10px; align-items:center; background:rgba(0,0,0,0.05);">
+      <div class="viz-card viz-world-map-shell">
+        <div class="viz-toolbar viz-toolbar-padded">
           <strong>Общая карта:</strong>
           <span class="viz-muted">${entities.length} объектов</span>
-          <div style="flex:1"></div>
-          <div class="map-legend" style="display:flex; gap:15px; font-size:0.8rem;">
-            <span><i style="background:var(--color-orange); width:10px; height:10px; display:inline-block; border-radius:50%"></i> Топонимы</span>
-            <span><i style="background:var(--color-gold); width:10px; height:10px; display:inline-block; border-radius:50%"></i> Языки</span>
+          <div class="viz-toolbar-spacer"></div>
+          <div class="map-legend viz-map-legend">
+            <span><i class="viz-map-marker viz-legend-dot-orange"></i> Топонимы</span>
+            <span><i class="viz-map-marker viz-legend-dot-gold"></i> Языки</span>
           </div>
         </div>
-        <div id="${mapId}" style="flex:1; width:100%; min-height:400px; background:#f0e8d8;"></div>
+        <div id="${mapId}" class="viz-world-map-leaflet"></div>
       </div>
     `;
 

--- a/v3_app.js
+++ b/v3_app.js
@@ -1045,7 +1045,7 @@ function wireSafeImageFallback(root) {
     if (!img || img.dataset.fallbackWired === '1') return;
     img.dataset.fallbackWired = '1';
     img.addEventListener('error', () => {
-      img.style.display = 'none';
+      img.hidden = true;
     }, { once: true });
   });
 }
@@ -1059,6 +1059,41 @@ function safeColor(value, fallback = '#888') {
   if (/^hsla?\(\s*[-]?\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\s*(,\s*(0|1|0?\.\d+)\s*)?\)$/i.test(raw)) return raw;
   if (/^[a-z]{3,20}$/i.test(raw)) return raw;
   return fallback;
+}
+
+function applyDataDrivenStyles(root) {
+  const scope = root && typeof root.querySelectorAll === 'function' ? root : document;
+  if (!scope || typeof scope.querySelectorAll !== 'function') return;
+  const clamp = (value, min, max, fallback) => {
+    const number = Number.parseFloat(String(value || ''));
+    if (!Number.isFinite(number)) return fallback;
+    return Math.max(min, Math.min(max, number));
+  };
+  scope.querySelectorAll('[data-bar-width-pct]').forEach((el) => {
+    el.style.width = `${clamp(el.dataset.barWidthPct, 0, 100, 0)}%`;
+  });
+  scope.querySelectorAll('[data-epoch-color]').forEach((el) => {
+    el.style.setProperty('--epoch-color', safeColor(el.dataset.epochColor, '#8a7050'));
+  });
+  scope.querySelectorAll('[data-family-color]').forEach((el) => {
+    el.style.background = safeColor(el.dataset.familyColor, '#888');
+  });
+  scope.querySelectorAll('[data-home-decl-padding]').forEach((el) => {
+    el.style.setProperty('--home-decl-padding', el.dataset.homeDeclPadding || '14px 20px');
+  });
+  scope.querySelectorAll('[data-home-inner-padding]').forEach((el) => {
+    el.style.setProperty('--home-inner-padding', el.dataset.homeInnerPadding || '14px 20px');
+  });
+  scope.querySelectorAll('[data-home-facts-space]').forEach((el) => {
+    el.style.setProperty('--home-facts-space', `${clamp(el.dataset.homeFactsSpace, 0, 40, 14)}px`);
+    el.style.setProperty('--home-facts-line-height', String(clamp(el.dataset.homeFactsLineHeight, 1, 2.5, 1.7)));
+  });
+  scope.querySelectorAll('[data-home-featured-padding]').forEach((el) => {
+    el.style.setProperty('--home-featured-padding', `${clamp(el.dataset.homeFeaturedPadding, 0, 40, 10)}px`);
+  });
+  scope.querySelectorAll('[data-scholar-recon-columns]').forEach((el) => {
+    el.style.setProperty('--scholar-recon-columns', String(clamp(el.dataset.scholarReconColumns, 1, 6, 3)));
+  });
 }
 
 function getCategoryColorClass(subcategory) {
@@ -2049,7 +2084,7 @@ function pushHistoryState() {
 function updateBackButton() {
   const btn = document.getElementById('back-btn');
   if (!btn) return;
-  btn.style.display = historyStack.length > 1 ? 'inline-flex' : 'none';
+  btn.hidden = historyStack.length <= 1;
 }
 
 async function copyCurrentUrl() {
@@ -6090,13 +6125,9 @@ function setMobileSheetOpen(open) {
   if (!backdrop || !sheet || typeof document === 'undefined') return;
   if (backdrop.classList && typeof backdrop.classList.toggle === 'function') {
     backdrop.classList.toggle('open', !!open);
-  } else {
-    backdrop.style.display = open ? 'block' : 'none';
   }
   if (sheet.classList && typeof sheet.classList.toggle === 'function') {
     sheet.classList.toggle('open', !!open);
-  } else {
-    sheet.style.transform = open ? 'translateY(0)' : 'translateY(101%)';
   }
   if (document.body && document.body.classList && typeof document.body.classList.toggle === 'function') {
     document.body.classList.toggle('mobile-sheet-lock', !!open);
@@ -6211,11 +6242,12 @@ function renderChapterHistogramRows(host, entityKey, focusedItem = null) {
     html += `
       <div class="bar-row">
         <div class="bar-label">${escapeHtml(ch.name)}<br><small>стр. ${ch.start}–${ch.end}</small></div>
-        <div class="bar-bg"><div class="bar-fill" data-chapter="${escapeHtml(ch.name)}" style="width:${pct}%"></div></div>
+        <div class="bar-bg"><div class="bar-fill" data-chapter="${escapeHtml(ch.name)}" data-bar-width-pct="${pct}"></div></div>
         <div class="bar-count">${c}</div>
       </div>`;
   }
   host.innerHTML = html;
+  applyDataDrivenStyles(host);
 }
 
 function renderHistogramInRight() {
@@ -6882,7 +6914,7 @@ function renderEpochsPanel(container) {
     const list = grouped[ep.key];
     const epochColor = safeColor(EPOCH_COLORS[ep.key], '#8a7050');
     html += `<div class="epoch-card">
-      <div class="epoch-card-head" style="--epoch-color:${epochColor};">
+      <div class="epoch-card-head" data-epoch-color="${escapeHtml(epochColor)}">
         <div class="epoch-card-title">${ep.label}</div>
         <div class="epoch-card-meta">${ep.sub} · ${list.length}</div>
       </div>
@@ -6895,6 +6927,7 @@ function renderEpochsPanel(container) {
   }
   html += '</div>';
   grid.innerHTML = html;
+  applyDataDrivenStyles(grid);
   bindNavigateLinks(grid, '.related-link[data-head]', 'toponyms');
 }
 
@@ -7273,7 +7306,7 @@ function renderGraphPanel(container) {
 
   if (!stage || typeof d3 === 'undefined' || !d3 || typeof d3.select !== 'function') {
     if (status) {
-      status.style.display = 'block';
+      status.hidden = false;
       status.textContent = 'D3.js is unavailable, graph view is disabled.';
     }
     return;
@@ -7331,12 +7364,12 @@ function renderGraphPanel(container) {
         summary.textContent = `nodes: ${nodes.length} - edges: ${links.length}`;
       }
       if (status) {
-        status.style.display = 'none';
+        status.hidden = true;
         status.textContent = '';
       }
       if (!nodes.length || !links.length) {
         if (status) {
-          status.style.display = 'block';
+          status.hidden = false;
           status.textContent = 'No edges for the selected threshold.';
         }
         stage.innerHTML = '';
@@ -7473,7 +7506,7 @@ function renderGraphPanel(container) {
     .catch((error) => {
       if (renderToken !== nameGraphRenderToken) return;
       if (status) {
-        status.style.display = 'block';
+        status.hidden = false;
         status.textContent = 'Failed to build graph.';
       }
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
@@ -7835,7 +7868,7 @@ function renderFamiliesPanel(container) {
 
     if (status) {
       status.textContent = '';
-      status.style.display = 'none';
+      status.hidden = true;
     }
 
     function eventToCanvasPoint(e) {
@@ -7995,9 +8028,10 @@ function renderFamiliesPanel(container) {
       for (const fam of families) {
         const div = document.createElement('div');
         div.className = 'legend-item';
-        div.innerHTML = `<span class="legend-dot" style="background:${safeColor(FAMILY_COLORS[fam], '#888')}"></span>${fam} (${familyCounts[fam] || 0})`;
+        div.innerHTML = `<span class="legend-dot" data-family-color="${escapeHtml(safeColor(FAMILY_COLORS[fam], '#888'))}"></span>${escapeHtml(fam)} (${familyCounts[fam] || 0})`;
         lg.appendChild(div);
       }
+      applyDataDrivenStyles(lg);
     }
     perfDebug('render-graph-families', nowMs() - t0, graphStrongOnly ? 'strong' : 'all');
   }
@@ -8007,7 +8041,7 @@ function renderFamiliesPanel(container) {
     .catch((error) => {
       if (renderToken !== familiesGraphRenderToken) return;
       if (status) {
-        status.style.display = 'block';
+        status.hidden = false;
         status.textContent = 'Не удалось рассчитать граф.';
       }
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
@@ -8392,7 +8426,7 @@ function renderHomePanelDeclarative(container) {
   }
 
   container.innerHTML = `<div class="panel active home-panel home-panel-declarative">
-    <div id="home-declarative-root" class="home-declarative-root" x-data="${HOME_DECL_FACTORY_KEY}()" style="--home-decl-padding:${viewModel.homeInnerPadding};">
+    <div id="home-declarative-root" class="home-declarative-root" x-data="${HOME_DECL_FACTORY_KEY}()" data-home-decl-padding="${escapeHtml(viewModel.homeInnerPadding)}">
       <div class="home-stats-hero">
         <div class="home-stats-head">
           <h2 class="home-stats-title">Book stats (declarative mode)</h2>
@@ -8409,7 +8443,7 @@ function renderHomePanelDeclarative(container) {
           </template>
         </div>
 
-        <div class="home-facts" style="--home-facts-space:${viewModel.compactHome ? 10 : 14}px;--home-facts-line-height:${viewModel.compactHome ? 1.55 : 1.7};">
+        <div class="home-facts" data-home-facts-space="${viewModel.compactHome ? 10 : 14}" data-home-facts-line-height="${viewModel.compactHome ? 1.55 : 1.7}">
           <div id="home-fact-pair-decl" class="${viewModel.factPairClass}">
             <div>
               <template x-for="(fact, idx) in facts" :key="idx">
@@ -8418,7 +8452,7 @@ function renderHomePanelDeclarative(container) {
                 </button>
               </template>
             </div>
-            <div id="home-featured-quote-decl" class="${viewModel.quoteClass}" style="--home-featured-padding:${viewModel.compactHome ? 8 : 10}px;">
+            <div id="home-featured-quote-decl" class="${viewModel.quoteClass}" data-home-featured-padding="${viewModel.compactHome ? 8 : 10}">
               <div class="${viewModel.quoteTextClass}" x-text="'&quot;' + featuredText + '&quot;'"></div>
               <div class="home-featured-meta" x-text="'page ' + featuredPage + ', lecture &quot;' + featuredLecture + '&quot;'"></div>
               <div class="home-featured-hint">Choose a path through the book and jump directly to cards.</div>
@@ -8469,6 +8503,7 @@ function renderHomePanelDeclarative(container) {
     </div>
   </div>`;
 
+  applyDataDrivenStyles(container);
   alpine.initTree(container);
 }
 
@@ -8487,7 +8522,7 @@ function renderHomePanel(container) {
   const quoteTextClass = compactHome ? 'home-featured-quote-clamp' : '';
   const routeGridClass = (compactHome || isDesktop) ? 'home-routes-grid home-routes-grid-compact' : 'home-routes-grid';
 
-  let html = `<div class="panel active home-panel"><div class="home-panel-inner" style="--home-inner-padding:${homeInnerPadding};">`;
+  let html = `<div class="panel active home-panel"><div class="home-panel-inner" data-home-inner-padding="${escapeHtml(homeInnerPadding)}">`;
 
   // === БЛОК 1: КНИГА В ЦИФРАХ ===
   html += `<div class="home-stats-hero">
@@ -8517,7 +8552,7 @@ function renderHomePanel(container) {
   html += '</div>';
 
   // Изюминки
-  html += `<div class="home-facts" style="--home-facts-space:${compactHome ? 10 : 14}px;--home-facts-line-height:${compactHome ? 1.55 : 1.7};">
+  html += `<div class="home-facts" data-home-facts-space="${compactHome ? 10 : 14}" data-home-facts-line-height="${compactHome ? 1.55 : 1.7}">
     <div id="home-fact-pair" class="${factPairClass}">
       <div>
         <div class="home-fact-row">📖 Самая длинная лекция — <strong>«${escapeHtml(stats.longest_lecture.name)}»</strong> (${stats.longest_lecture.pages} страниц)</div>
@@ -8528,7 +8563,7 @@ function renderHomePanel(container) {
         <div class="home-fact-row">⏳ Самый ранний из упомянутых — <strong>${escapeHtml(stats.earliest_person.head)}</strong> (${Math.abs(stats.earliest_person.epoch)} ${stats.earliest_person.epoch < 0 ? 'до н.&nbsp;э.' : 'г.'})</div>
         <div class="home-fact-row">🌐 Самая представленная семья — <strong>${escapeHtml(stats.top_family[0])}</strong> (${stats.top_family[1]} языков)</div>
       </div>
-      <div id="home-featured-quote" class="${quoteClass}" style="--home-featured-padding:${compactHome ? 8 : 10}px;">
+      <div id="home-featured-quote" class="${quoteClass}" data-home-featured-padding="${compactHome ? 8 : 10}">
         <div id="home-featured-quote-text" class="${quoteTextClass}">«${escapeHtml(featured.text)}»</div>
         <div class="home-featured-meta">— ${renderTextWithPageLinks(`стр. ${featured.page}`, { className: 'material-page-link card-page-link related-link home-featured-page-link', rangeTarget: 'trends' })}, лекция «${escapeHtml(featured.lecture)}»</div>
         <div class="home-featured-hint">Выберите свой путь по книге — если не знаете, с чего начать, выберите тему, которая вас интересует.</div>
@@ -8574,6 +8609,7 @@ function renderHomePanel(container) {
   html += '</div></div>';
 
   container.innerHTML = html;
+  applyDataDrivenStyles(container);
   const homeFactPair = document.getElementById('home-fact-pair');
   if (homeFactPair) {
     const pairChildren = homeFactPair.children || [];
@@ -9982,7 +10018,7 @@ function renderGlossaryPanel(container) {
     const q = (value || '').trim().toLowerCase();
     container.querySelectorAll('.glossary-entry').forEach(el => {
       const t = el.dataset.term;
-      el.style.display = (!q || t.includes(q)) ? 'block' : 'none';
+      el.hidden = !!(q && !t.includes(q));
     });
   };
   const focusGlossaryEntry = (term) => {
@@ -11139,7 +11175,7 @@ function renderScholarPanel(container) {
   const recon = APP_DATA.lexicon_tech || [];
   html += '<h3 id="sch-reconstructions" class="scholar-section-title scholar-section-title-spaced">11. Реконструкции</h3>';
   html += `<div class="scholar-section-intro">${recon.length} реконструированных и иноязычных форм, вынесенных в подраздел профессионального аппарата.</div>`;
-  html += `<div class="scholar-recon-grid" style="--scholar-recon-columns:${reconstructionColumns};">`;
+  html += `<div class="scholar-recon-grid" data-scholar-recon-columns="${reconstructionColumns}">`;
   for (const item of recon) {
     html += `<a class="scholar-link scholar-recon-link" data-type="lexicon_tech" data-head="${escapeHtml(item.head)}" href="${escapeHtml(buildItemHash('lexicon_tech', item.head))}">
       <span class="scholar-recon-head">${escapeHtml(item.head)}</span>
@@ -11150,6 +11186,7 @@ function renderScholarPanel(container) {
 
   html += '</div></div>';
   container.innerHTML = html;
+  applyDataDrivenStyles(container);
 
   // Привязки кликов на имена
   const exportScholarBiblioBibBtn = container.querySelector('#export-scholar-biblio-bib');
@@ -11241,8 +11278,8 @@ function renderScholarPanel(container) {
         const norms = cells.map(stripAccents).filter(Boolean);
         const same = norms.length > 1 && norms.every((n) => n === norms[0]);
         const cellHtml = cells.map((cell) => {
-          const bg = !same && cell ? 'background:#fff3e4;' : '';
-          return `<td class="scholar-compare-cell" style="${bg}">${cell ? renderAccentSafe(cell) : '<span class="scholar-compare-missing">—</span>'}</td>`;
+          const compareClass = !same && cell ? ' scholar-compare-cell-mismatch' : '';
+          return `<td class="scholar-compare-cell${compareClass}">${cell ? renderAccentSafe(cell) : '<span class="scholar-compare-missing">—</span>'}</td>`;
         }).join('');
         htmlRows.push(`<tr><td class="scholar-compare-row-index">${i + 1}</td>${cellHtml}</tr>`);
         mdRows.push(`| ${i + 1} | ${cells.map(mdEscapeCell).join(' | ')} |`);
@@ -11307,7 +11344,7 @@ function renderScholarPanel(container) {
       const byLaw = !law || rowLaw === law;
       const byLang = !lang || langs.includes(lang);
       const visible = byFamily && byLaw && byLang;
-      row.style.display = visible ? '' : 'none';
+      row.hidden = !visible;
       if (visible) shown += 1;
     }
     if (!corrBody) return;
@@ -11368,7 +11405,7 @@ function renderScholarPanel(container) {
       const byCentury = !century || rowCentury === century;
       const byNum = !numNeedle || rowNum.includes(numNeedle);
       const visible = byCity && byCentury && byNum;
-      row.style.display = visible ? '' : 'none';
+      row.hidden = !visible;
       if (visible) shown += 1;
     }
     if (!birchBody) return;

--- a/v3_template.html
+++ b/v3_template.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' __CSP_SCRIPT_HASHES__; worker-src 'self' blob:; style-src 'self' __CSP_STYLE_HASHES__; style-src-elem 'self' __CSP_STYLE_HASHES__; style-src-attr 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' https:; font-src 'self' data: https:; frame-src https:; object-src 'none'; base-uri 'self'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' __CSP_SCRIPT_HASHES__; worker-src 'self' blob:; style-src 'self' __CSP_STYLE_HASHES__; style-src-elem 'self' __CSP_STYLE_HASHES__; style-src-attr 'none'; img-src 'self' data: blob: https:; connect-src 'self' https:; font-src 'self' data: https:; frame-src https:; object-src 'none'; base-uri 'self'; form-action 'self'">
 <meta name="theme-color" content="#5a3818">
 <meta name="color-scheme" content="light">
 <meta name="application-name" content="BookIndex">
@@ -151,7 +151,7 @@
     margin-top: 6px;
   }
   .back-btn {
-    display: none;
+    display: inline-flex;
     align-items: center;
     gap: 4px;
     padding: 5px 9px;
@@ -162,6 +162,9 @@
     font-family: inherit;
     font-size: 12px;
     cursor: pointer;
+  }
+  .back-btn[hidden] {
+    display: none;
   }
   .header-search {
     position: relative;
@@ -807,6 +810,353 @@
     border-radius: 50%;
     display: inline-block;
   }
+  .viz-legend-dot-primary { background: var(--color-primary); }
+  .viz-legend-dot-gold { background: var(--color-gold); }
+  .viz-legend-dot-orange { background: var(--color-orange); }
+  .viz-legend-color-0 { background: #4e79a7; }
+  .viz-legend-color-1 { background: #f28e2c; }
+  .viz-legend-color-2 { background: #e15759; }
+  .viz-legend-color-3 { background: #76b7b2; }
+  .viz-legend-color-4 { background: #59a14f; }
+  .viz-legend-color-5 { background: #edc949; }
+  .viz-legend-color-6 { background: #af7aa1; }
+  .viz-legend-color-7 { background: #ff9da7; }
+  .viz-legend-color-8 { background: #9c755f; }
+  .viz-legend-color-9 { background: #bab0ab; }
+  .viz-legend-color-10 { background: #8dd3c7; }
+  .viz-legend-color-11 { background: #ffffb3; }
+  .viz-legend-color-12 { background: #bebada; }
+  .viz-legend-color-13 { background: #fb8072; }
+  .viz-legend-color-14 { background: #80b1d3; }
+  .viz-legend-color-15 { background: #fdb462; }
+  .viz-legend-color-16 { background: #b3de69; }
+  .viz-legend-color-17 { background: #fccde5; }
+  .viz-legend-color-18 { background: #d9d9d9; }
+  .viz-legend-color-19 { background: #bc80bd; }
+  .viz-legend-color-20 { background: #ccebc5; }
+  .viz-legend-color-21 { background: #ffed6f; }
+  .viz-card-fill {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .viz-card-scroll {
+    height: 100%;
+    overflow: auto;
+    background: var(--bg);
+  }
+  .viz-toolbar-padded {
+    padding: 10px;
+    background: rgba(0,0,0,0.05);
+  }
+  .viz-toolbar-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+  .viz-toolbar-spacer {
+    flex: 1;
+  }
+  .viz-card-pad {
+    padding: 20px;
+  }
+  .viz-svg-bg {
+    background: var(--bg);
+  }
+  .viz-svg-wrap {
+    position: relative;
+  }
+  .viz-tooltip-floating {
+    position: absolute;
+  }
+  .viz-map-legend {
+    display: flex;
+    gap: 15px;
+    font-size: 0.8rem;
+  }
+  .viz-map-marker {
+    width: 10px;
+    height: 10px;
+    display: inline-block;
+    border-radius: 50%;
+  }
+  .viz-world-map-shell {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  .viz-world-map-leaflet {
+    flex: 1;
+    width: 100%;
+    min-height: 400px;
+    background: #f0e8d8;
+  }
+  .viz-comparative-timeline {
+    background: #1c1b18;
+    color: #eee;
+    padding: 2rem;
+    border-radius: 12px;
+  }
+  .viz-comparative-title {
+    margin-top: 0;
+    color: #80deea;
+  }
+  .axis-line {
+    stroke: rgba(255,255,255,0.2);
+  }
+  .timeline-event {
+    cursor: pointer;
+    transition: 0.2s;
+  }
+  .timeline-event:hover circle {
+    r: 8;
+    stroke: #80deea;
+  }
+  .event-label {
+    font-size: 10px;
+    fill: #aaa;
+    font-family: 'Inter', sans-serif;
+  }
+  .lane-label {
+    font-size: 12px;
+    font-weight: 700;
+    fill: #80deea;
+    text-transform: uppercase;
+  }
+  .viz-semantic-graph {
+    background: #1a1a1a;
+    color: #eee;
+    border-radius: 12px;
+    overflow: hidden;
+    position: relative;
+  }
+  .viz-semantic-graph .viz-toolbar {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    z-index: 10;
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 0;
+  }
+  .viz-btn {
+    background: rgba(255,255,255,0.1);
+    border: 1px solid rgba(255,255,255,0.2);
+    color: #fff;
+    padding: 5px 15px;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: 0.2s;
+    font-size: 0.85rem;
+  }
+  .viz-btn:hover {
+    background: rgba(128, 222, 234, 0.2);
+    border-color: #80deea;
+  }
+  .viz-semantic-legend {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    display: block;
+    background: rgba(0,0,0,0.5);
+    padding: 10px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    backdrop-filter: blur(5px);
+    margin-bottom: 0;
+  }
+  .viz-semantic-status {
+    font-size: 0.8rem;
+    opacity: 0.7;
+  }
+  .viz-semantic-legend-name { color: #80deea; }
+  .viz-semantic-legend-lang { color: #b388ff; }
+  .viz-semantic-legend-lex { color: #26a69a; }
+  .node-glow {
+    filter: drop-shadow(0 0 5px currentColor);
+  }
+  .link-line {
+    stroke-opacity: 0.2;
+  }
+  .node-label {
+    font-family: 'Inter', sans-serif;
+    font-weight: 500;
+    pointer-events: none;
+  }
+  .corpus-timeline {
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    color: #e0e0e0;
+    padding: 2rem;
+    max-width: 1000px;
+    margin: 0 auto;
+    background:
+      radial-gradient(circle at top right, rgba(103, 58, 183, 0.1), transparent),
+      radial-gradient(circle at bottom left, rgba(0, 150, 136, 0.1), transparent);
+  }
+  .corpus-timeline .timeline-header {
+    text-align: center;
+    margin-bottom: 4rem;
+  }
+  .corpus-timeline .timeline-header h1 {
+    font-size: 3rem;
+    font-weight: 800;
+    background: linear-gradient(135deg, #b388ff, #80deea);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    margin-bottom: 0.5rem;
+  }
+  .corpus-timeline .timeline-scroll-container {
+    position: relative;
+    padding-left: 3rem;
+  }
+  .corpus-timeline .timeline-track {
+    position: absolute;
+    left: 15px;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: linear-gradient(to bottom, #b388ff, #80deea, #b388ff);
+    border-radius: 2px;
+    opacity: 0.3;
+  }
+  .corpus-timeline .timeline-item-wrapper {
+    position: relative;
+    margin-bottom: 3rem;
+    opacity: 0;
+    transform: translateY(20px);
+    animation: fadeInSlide 0.6s forwards;
+  }
+  @keyframes fadeInSlide {
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .corpus-timeline .timeline-dot {
+    position: absolute;
+    left: -23px;
+    top: 25px;
+    width: 20px;
+    height: 20px;
+    background: #b388ff;
+    border: 4px solid #1a1a1a;
+    border-radius: 50%;
+    z-index: 2;
+    box-shadow: 0 0 15px rgba(179, 136, 255, 0.6);
+  }
+  .corpus-timeline .lecture-card {
+    background: rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 20px;
+    padding: 1.5rem;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    overflow: hidden;
+  }
+  .corpus-timeline .lecture-card:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(179, 136, 255, 0.4);
+    transform: translateX(10px);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  }
+  .corpus-timeline .card-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+  }
+  .corpus-timeline .lecture-icon {
+    font-size: 2.5rem;
+    background: rgba(179, 136, 255, 0.1);
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 15px;
+  }
+  .corpus-timeline .lecture-pages {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #80deea;
+  }
+  .corpus-timeline .lecture-title {
+    font-size: 1.4rem;
+    margin: 0.2rem 0;
+  }
+  .corpus-timeline .card-content {
+    margin-top: 1rem;
+  }
+  .corpus-timeline .main-idea {
+    font-size: 1.1rem;
+    line-height: 1.6;
+    color: #bbb;
+  }
+  .corpus-timeline .details {
+    max-height: 0;
+    opacity: 0;
+    transition: all 0.5s ease;
+    overflow: hidden;
+  }
+  .corpus-timeline .lecture-card.expanded .details {
+    max-height: 800px;
+    opacity: 1;
+    margin-top: 1.5rem;
+  }
+  .corpus-timeline .details h4 {
+    color: #b388ff;
+    margin-bottom: 0.5rem;
+  }
+  .corpus-timeline .details ul {
+    list-style: none;
+    padding: 0;
+  }
+  .corpus-timeline .details li {
+    margin-bottom: 0.5rem;
+    padding-left: 1.5rem;
+    position: relative;
+  }
+  .corpus-timeline .details li::before {
+    content: '>';
+    position: absolute;
+    left: 0;
+    color: #80deea;
+  }
+  .corpus-timeline .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+  }
+  .corpus-timeline .term-tag {
+    background: rgba(128, 222, 234, 0.1);
+    border: 1px solid rgba(128, 222, 234, 0.2);
+    color: #80deea;
+    padding: 0.3rem 0.8rem;
+    border-radius: 20px;
+    font-size: 0.85rem;
+    transition: all 0.2s;
+  }
+  .corpus-timeline .term-tag:hover {
+    background: rgba(128, 222, 234, 0.2);
+    border-color: #80deea;
+  }
+  .corpus-timeline .card-footer {
+    margin-top: 1rem;
+    text-align: right;
+  }
+  .corpus-timeline .expand-btn {
+    background: transparent;
+    border: none;
+    color: #b388ff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0;
+  }
   .viz-muted {
     color: var(--muted);
     font-size: 11px;
@@ -859,6 +1209,15 @@
   .tl-item.tl-focus {
     outline: 2px solid var(--line-strong);
     outline-offset: 1px;
+  }
+  .tl-item-discovery {
+    border-left: 4px solid var(--primary);
+  }
+  .tl-item-linguist {
+    border-left: 4px solid #3a6ea5;
+  }
+  .tl-item-historical {
+    border-left: 4px solid #c0392b;
   }
   .tl-year {
     font-size: 12px;
@@ -3441,6 +3800,9 @@
     border-top: 1px solid #f0e8d8;
     padding: 6px 8px;
   }
+  .scholar-compare-cell-mismatch {
+    background: #fff3e4;
+  }
   .scholar-compare-missing {
     color: #bbb;
   }
@@ -4501,7 +4863,7 @@
   <h1>
     <span class="title-group">
       <a id="home-link" class="home-link" href="#v4/home/home">Зализнякиада (сопроводительный сайт-справочник)</a>
-      <button class="back-btn" id="back-btn" type="button">← назад</button>
+      <button class="back-btn" id="back-btn" type="button" hidden>← назад</button>
       <select class="density-select" id="density-select" aria-label="Плотность интерфейса" title="Плотность интерфейса">
         <option value="compact">плотно</option>
         <option value="reader">чтение</option>


### PR DESCRIPTION
## Summary
- Deny inline style attributes with `style-src-attr 'none'` in the landing page, app shell, and generated standalone build.
- Move app and visualization inline style attributes into static CSS classes or data-driven runtime styling.
- Extend security/static guards so runtime modules cannot reintroduce inline `style="..."` attributes or injected `<style>` blocks.

## Validation
- `npm run build`
- `npm run check:ui`
- `npm run check:security:static`
- `npm run check:js`
- local Playwright CSP smoke across `viz01` through `viz07`
- `npm run check`
- `npm run check:security`
- `python runtime_test.py`