### PR TITLE
CodeQL: skip generated prerendered pages and vendored libs (fix 10-min timeout)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,32 @@
 name: BookIndex CodeQL config
 
+# CodeQL must analyse only hand-written JavaScript source (v3_app.js, scripts/, src/,
+# tests/, top-level configs). The directories below are committed BUILD ARTIFACTS, not
+# source: scripts/prerender.mjs (run by `npm run build`) emits ~700 prerendered
+# index.html pages, and EACH inlines the full ~632 KiB v3_app.js plus JSON-LD and a
+# redirect script. Extracting JS from all of them blows past the 10-minute job cap, so
+# every run on main was cancelled ("The operation was canceled"). Their JS is identical
+# to v3_app.js, which is already analysed on its own, so excluding them loses no coverage.
 paths-ignore:
   - aaz-index.html
+  # Prerendered category pages: <cat>/list/index.html and <cat>/list/item/**/index.html
+  # (all, names, toponyms, ethnonyms, languages, lexicon, lexicon_reverse, lexicon_tech,
+  # subject). Whole dirs are generated HTML — no JS source lives under them. If a new
+  # top-level category is ever added, add its dir here too.
+  - all/**
+  - names/**
+  - toponyms/**
+  - ethnonyms/**
+  - languages/**
+  - lexicon/**
+  - lexicon_reverse/**
+  - lexicon_tech/**
+  - subject/**
+  # Prerendered materials (lecture_pages/**, lectures, sources, tasks) and scholar/viz.
+  - materials/**
+  - scholar/**
+  # Vendored minified libraries (root + public copy) and the runtime build copy
+  # (duplicate of v3_app.js + vendor).
+  - vendor/**
+  - public/vendor/**
+  - dist-runtime/**


### PR DESCRIPTION
## Problem

The **Analyze JavaScript** CodeQL job is cancelled on **every** push to `main` — it exceeds the 10-minute `timeout-minutes` cap and GitHub kills it (`The operation was canceled`).

```
$ gh run list --workflow=codeql.yml --branch main --limit 8 --json conclusion,displayTitle
# → recent runs: "cancelled"
```

### Root cause

CodeQL's JS extractor has to chew through ~700 committed **prerendered** `index.html` pages. Each one inlines the full ~632 KiB [`v3_app.js`](https://github.com/gasyoun/BookIndex/blob/main/v3_app.js) plus JSON-LD and a redirect script (≈ hundreds of MB of duplicated JS). Those pages are build artifacts produced by [`scripts/prerender.mjs`](https://github.com/gasyoun/BookIndex/blob/main/scripts/prerender.mjs) (run automatically at the end of `npm run build`) — their JavaScript is identical to `v3_app.js`, which CodeQL already analyses on its own. The previous [`paths-ignore`](https://github.com/gasyoun/BookIndex/blob/main/.github/codeql/codeql-config.yml) only excluded `aaz-index.html`.

## Fix

Extend `paths-ignore` in [`.github/codeql/codeql-config.yml`](https://github.com/gasyoun/BookIndex/blob/fix/codeql-skip-prerendered-pages/.github/codeql/codeql-config.yml) to drop the generated-HTML directories and the vendored/minified libraries, so CodeQL only scans hand-written source:

- Prerendered category pages — `all/`, `names/`, `toponyms/`, `ethnonyms/`, `languages/`, `lexicon/`, `lexicon_reverse/`, `lexicon_tech/`, `subject/` (each is `<cat>/list/...`, 100% generated HTML)
- Prerendered `materials/` (lecture_pages, lectures, sources, tasks) and `scholar/viz`
- Vendored minified libs — `vendor/`, `public/vendor/`
- Runtime build copy — `dist-runtime/` (duplicate of `v3_app.js` + vendor)

I used `paths-ignore` rather than a `paths:` allowlist deliberately: real source is scattered across top-level files (`v3_app.js`, `vite.config.mjs`, `playwright.config.js`) plus `scripts/`, `src/`, `tests/`, `experimental/`, so an allowlist would risk silently dropping real source. Verified that **none** of the excluded directories contain any tracked `.js`/`.mjs`/`.ts` source — only vendored minified libs and the runtime build copy.

## Scope

- Config-only change. No app code touched, no artifacts regenerated.
- YAML-only, so `core.autocrlf` line endings are a non-issue.

## Validation

The CodeQL run triggered by this PR should complete the **Analyze JavaScript** job well under 10 minutes and pass green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)