### PR TITLE
Fix chronic CodeQL JS timeout: ignore generated pages + vendored libs

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,26 @@
 name: BookIndex CodeQL config
 
+# CodeQL (javascript-typescript) extracts JS inlined in HTML. The standalone app
+# (aaz-index.html) and the ~700 prerendered index pages each inline the full
+# ~632 KiB app script, so extracting them overruns the 10-minute analysis budget
+# and the "Analyze JavaScript" job is cancelled on every commit. Those pages are
+# generated build artifacts (npm run build -> scripts/prerender.mjs); their JS is
+# identical to v3_app.js, which is scanned directly. Ignore generated output and
+# vendored/minified libraries so CodeQL scans only real source (index.html,
+# v3_app.js, src/, scripts/, tests/, configs).
 paths-ignore:
   - aaz-index.html
+  - all/**
+  - names/**
+  - toponyms/**
+  - ethnonyms/**
+  - languages/**
+  - lexicon/**
+  - lexicon_reverse/**
+  - lexicon_tech/**
+  - subject/**
+  - materials/**
+  - scholar/**
+  - vendor/**
+  - dist-runtime/**
+  - dist-vite/**


### PR DESCRIPTION
## Problem

The **CodeQL** workflow's `Analyze JavaScript` job is **cancelled by timeout on every commit to `main`** (10-minute cap → "The operation was canceled"). Recent `main` history shows CodeQL `cancelled` for every commit.

### Root cause

CodeQL (`javascript-typescript`, `build-mode: none`) extracts JavaScript inlined in HTML. The standalone app and the **~700 prerendered index pages each inline the full ~632 KiB app script** (`v3_app.js`), so extraction alone (~700 × 632 KiB) overruns the budget. The config at [`.github/codeql/codeql-config.yml`](https://github.com/gasyoun/BookIndex/blob/main/.github/codeql/codeql-config.yml) only ignored `aaz-index.html`, leaving all the generated pages and the tracked `vendor/` + `dist-runtime/` copies in scope.

## Fix

Extend `paths-ignore` to drop generated build artifacts and vendored/minified libraries. These pages are produced by `npm run build` → `scripts/prerender.mjs`; their JS is identical to `v3_app.js`, which CodeQL still scans directly.

Ignored: `aaz-index.html`, the prerender output dirs (`all`, `names`, `toponyms`, `ethnonyms`, `languages`, `lexicon`, `lexicon_reverse`, `lexicon_tech`, `subject`, `materials`, `scholar`), and `vendor` / `dist-runtime` / `dist-vite`.

**Real source is still scanned** — verified each ignored category dir contains only generated `index.html` files (no hand-written source), and the following remain in scope: root `index.html`, `404.html`, `v3_template.html`, `v3_app.js`, `src/`, `scripts/`, `tests/`, `experimental/`, `types/`, and the config files.

## Verification

YAML parses cleanly (15 `paths-ignore` entries). The real proof is this PR's own **`Analyze JavaScript`** run: it should now complete well under the 10-minute cap instead of being cancelled. (This change is config-only — no app code, no regenerated artifacts.)

Separate from, and complementary to, the CSP/post-deploy fix in [#110](https://github.com/gasyoun/BookIndex/pull/110).
